### PR TITLE
Fixed deadlock for agents in complex example

### DIFF
--- a/Demo/Assets/Demos/Complex/Behaviours/ComplexAgentBrain.cs
+++ b/Demo/Assets/Demos/Complex/Behaviours/ComplexAgentBrain.cs
@@ -28,12 +28,14 @@ namespace Demos.Complex.Behaviours
         {
             this.agent.Events.OnActionStop += this.OnActionStop;
             this.agent.Events.OnNoActionFound += this.OnNoActionFound;
+            this.agent.Events.OnGoalCompleted += this.OnGoalCompleted;
         }
 
         private void OnDisable()
         {
             this.agent.Events.OnActionStop -= this.OnActionStop;
             this.agent.Events.OnNoActionFound -= this.OnNoActionFound;
+            this.agent.Events.OnGoalCompleted -= this.OnGoalCompleted;
         }
 
         private void Start()
@@ -42,6 +44,11 @@ namespace Demos.Complex.Behaviours
         }
         
         private void OnNoActionFound(IGoalBase goal)
+        {
+            this.agent.SetGoal<WanderGoal>(false);
+        }
+
+        private void OnGoalCompleted(IGoalBase goal)
         {
             this.agent.SetGoal<WanderGoal>(false);
         }

--- a/Demo/Assets/Demos/Complex/Factories/Extensions/GoalExtensions.cs
+++ b/Demo/Assets/Demos/Complex/Factories/Extensions/GoalExtensions.cs
@@ -19,7 +19,7 @@ namespace Demos.Complex.Factories.Extensions
             where T : ICreatable
         {
             builder.AddGoal<CreateItemGoal<T>>()
-                .AddCondition<CreatedItem<T>>(Comparison.GreaterThanOrEqual, 1);
+                .AddCondition<CreatedItem<T>>(Comparison.GreaterThanOrEqual, 999);
         }
 
         public static void AddCleanItemsGoal(this GoapSetBuilder builder)
@@ -38,7 +38,7 @@ namespace Demos.Complex.Factories.Extensions
             where T : IGatherable
         {
             builder.AddGoal<GatherItemGoal<T>>()
-                .AddCondition<IsInWorld<T>>(Comparison.GreaterThanOrEqual, 1);
+                .AddCondition<IsInWorld<T>>(Comparison.GreaterThanOrEqual, 999);
         }
         
         public static void AddPickupItemGoal<T>(this GoapSetBuilder builder)

--- a/Package/package.json
+++ b/Package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.crashkonijn.goap",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "displayName": "Unity GOAP",
   "description": "An open source GOAP implementation for unity",
   "unity": "2022.2",


### PR DESCRIPTION
Agents could get into a goal deadlock, the newly introduced `onGoalCompleted` event prevented the resolver from doing an action multiple twice, even if the goal was technically 'completed'.

I've fixed this in two ways:
- Added OnGoalCompleted event to `ComplexAgentBrain`, this will always prevent a deadlock.
- Increased the values used in the goals. This will prevent the goal being completed incorrectly.