### PR TITLE
Method renaming:  GetComponent<T> becomes GetCachedComponent<T>

### DIFF
--- a/Demo/Assets/Demos/Complex/Sensors/World/IsHoldingSensor.cs
+++ b/Demo/Assets/Demos/Complex/Sensors/World/IsHoldingSensor.cs
@@ -20,7 +20,7 @@ namespace Demos.Complex.Sensors.World
 
         public override SenseValue Sense(IMonoAgent agent, IComponentReference references)
         {
-            var inventory = references.GetComponent<ComplexInventoryBehaviour>();
+            var inventory = references.GetCachedComponent<ComplexInventoryBehaviour>();
             
             if (inventory == null)
                 return false;

--- a/Demo/Assets/Demos/Simple/Sensors/World/HasAppleSensor.cs
+++ b/Demo/Assets/Demos/Simple/Sensors/World/HasAppleSensor.cs
@@ -18,7 +18,7 @@ namespace Demos.Simple.Sensors.World
 
         public override SenseValue Sense(IMonoAgent agent, IComponentReference references)
         {
-            var inventory = references.GetComponent<InventoryBehaviour>();
+            var inventory = references.GetCachedComponent<InventoryBehaviour>();
 
             if (inventory == null)
                 return false;

--- a/Demo/Assets/Demos/Simple/Sensors/World/IsHungrySensor.cs
+++ b/Demo/Assets/Demos/Simple/Sensors/World/IsHungrySensor.cs
@@ -18,7 +18,7 @@ namespace Demos.Simple.Sensors.World
 
         public override SenseValue Sense(IMonoAgent agent, IComponentReference references)
         {
-            var hungerBehaviour = references.GetComponent<HungerBehaviour>();
+            var hungerBehaviour = references.GetCachedComponent<HungerBehaviour>();
 
             if (hungerBehaviour == null)
                 return false;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/References/DataReferenceInjector.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/References/DataReferenceInjector.cs
@@ -38,15 +38,15 @@ namespace CrashKonijn.Goap.Classes.References
         private object GetPropertyValue(PropertyInfo property)
         {
             if (property.GetCustomAttributes(typeof(GetComponentAttribute), true).Any())
-                return this.GetComponentReference(property.PropertyType);
+                return this.GetCachedComponentReference(property.PropertyType);
             
             if (property.GetCustomAttributes(typeof(GetComponentInChildrenAttribute), true).Any())
-                return this.GetComponentInChildrenReference(property.PropertyType);
+                return this.GetCachedComponentInChildrenReference(property.PropertyType);
             
             return null;
         }
 
-        private object GetComponentReference(Type type)
+        private object GetCachedComponentReference(Type type)
         {
             // check if we have a reference for this type
             if (!this.references.ContainsKey(type))
@@ -56,13 +56,21 @@ namespace CrashKonijn.Goap.Classes.References
             return this.references[type];
         }
 
+        [System.Obsolete("'GetComponent<T>' is deprecated, please use 'GetCachedComponent<T>' instead.   Exact same functionality, name changed to better communicate code usage.")]
         public T GetComponent<T>()
             where T : MonoBehaviour
         {
-            return (T) this.GetComponentReference(typeof(T));
+            return (T) this.GetCachedComponentReference(typeof(T));
         }
 
-        private object GetComponentInChildrenReference(Type type)
+        
+        public T GetCachedComponent<T>()
+            where T : MonoBehaviour
+        {
+            return (T)this.GetCachedComponentReference(typeof(T));
+        }
+
+        private object GetCachedComponentInChildrenReference(Type type)
         {
             // check if we have a reference for this type
             if (!this.references.ContainsKey(type))
@@ -72,10 +80,17 @@ namespace CrashKonijn.Goap.Classes.References
             return this.references[type];
         }
 
+        [System.Obsolete("'GetComponentInChildren<T>' is deprecated, please use 'GetCachedComponentInChildren<T>' instead.   Exact same functionality, name changed to better communicate code usage.")]
         public T GetComponentInChildren<T>()
             where T : MonoBehaviour
         {
-            return (T) this.GetComponentInChildrenReference(typeof(T));
+            return (T) this.GetCachedComponentInChildrenReference(typeof(T));
+        }
+
+        public T GetCachedComponentInChildren<T>()
+            where T : MonoBehaviour
+        {
+            return (T)this.GetCachedComponentInChildrenReference(typeof(T));
         }
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap/Classes/References/DataReferenceInjector.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/References/DataReferenceInjector.cs
@@ -62,7 +62,6 @@ namespace CrashKonijn.Goap.Classes.References
         {
             return (T) this.GetCachedComponentReference(typeof(T));
         }
-
         
         public T GetCachedComponent<T>()
             where T : MonoBehaviour
@@ -86,7 +85,6 @@ namespace CrashKonijn.Goap.Classes.References
         {
             return (T) this.GetCachedComponentInChildrenReference(typeof(T));
         }
-
         public T GetCachedComponentInChildren<T>()
             where T : MonoBehaviour
         {

--- a/Package/Runtime/CrashKonijn.Goap/Interfaces/IComponentReference.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Interfaces/IComponentReference.cs
@@ -4,10 +4,19 @@ namespace CrashKonijn.Goap.Interfaces
 {
     public interface IComponentReference
     {
+        [System.Obsolete("'GetComponent<T>' is deprecated, please use 'GetCachedComponent<T>' instead.   Exact same functionality, name changed to better communicate code usage.")]
         T GetComponent<T>()
             where T : MonoBehaviour;
-        
+
+        T GetCachedComponent<T>()
+            where T : MonoBehaviour;
+
+
+        [System.Obsolete("'GetComponentInChildren<T>' is deprecated, please use 'GetCachedComponentInChildren<T>' instead.   Exact same functionality, name changed to better communicate code usage.")]
         T GetComponentInChildren<T>()
+            where T : MonoBehaviour;
+
+        T GetCachedComponentInChildren<T>()
             where T : MonoBehaviour;
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap/Interfaces/IComponentReference.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Interfaces/IComponentReference.cs
@@ -11,7 +11,6 @@ namespace CrashKonijn.Goap.Interfaces
         T GetCachedComponent<T>()
             where T : MonoBehaviour;
 
-
         [System.Obsolete("'GetComponentInChildren<T>' is deprecated, please use 'GetCachedComponentInChildren<T>' instead.   Exact same functionality, name changed to better communicate code usage.")]
         T GetComponentInChildren<T>()
             where T : MonoBehaviour;


### PR DESCRIPTION
Method renaming:  GetComponent<T> becomes GetCachedComponent<T> to better communicate purpose.   For backward compatibility, previous versions retained but marked as obsolete.   Revised uses in the demo project also.