### PR TITLE
Major name refactor to change all derivatives of 'Set' to 'GoapSet'.

### DIFF
--- a/Demo/Assets/Demos/Complex/Behaviours/AgentSpawnBehaviour.cs
+++ b/Demo/Assets/Demos/Complex/Behaviours/AgentSpawnBehaviour.cs
@@ -43,7 +43,7 @@ namespace Demos.Complex.Behaviours
         {
             var agent = Instantiate(this.agentPrefab, this.GetRandomPosition(), Quaternion.identity).GetComponent<AgentBehaviour>();
             
-            agent.GoapSet = this.goapRunner.GetSet(setId);
+            agent.GoapSet = this.goapRunner.GetGoapSet(setId);
             agent.gameObject.SetActive(true);
             
             agent.gameObject.transform.name = $"{agentType} {agent.GetInstanceID()}";

--- a/Demo/Assets/Demos/Complex/Prefabs/ComplexAgent.prefab
+++ b/Demo/Assets/Demos/Complex/Prefabs/ComplexAgent.prefab
@@ -232,6 +232,7 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &4214390246634792387
 GameObject:
   m_ObjectHideFlags: 0
@@ -424,6 +425,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0

--- a/Demo/Assets/Demos/Complex/Scenes/ComplexDemoScene.unity
+++ b/Demo/Assets/Demos/Complex/Scenes/ComplexDemoScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -569,12 +569,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   configInitializer: {fileID: 395702497}
-  setConfigFactories:
+  setConfigFactories: []
+  goapSetConfigFactories:
   - {fileID: 395702498}
   - {fileID: 395702500}
   - {fileID: 395702499}
   - {fileID: 395702501}
-  goapSetConfigFactories: []
 --- !u!4 &395702494
 Transform:
   m_ObjectHideFlags: 0
@@ -1028,7 +1028,6 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
-  m_AllowHDROutput: 1
   m_UseScreenCoordOverride: 0
   m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}

--- a/Demo/Assets/Demos/Complex/Scenes/ComplexDemoScene.unity
+++ b/Demo/Assets/Demos/Complex/Scenes/ComplexDemoScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -574,6 +574,7 @@ MonoBehaviour:
   - {fileID: 395702500}
   - {fileID: 395702499}
   - {fileID: 395702501}
+  goapSetConfigFactories: []
 --- !u!4 &395702494
 Transform:
   m_ObjectHideFlags: 0
@@ -1027,6 +1028,7 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
   m_UseScreenCoordOverride: 0
   m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}

--- a/Demo/Assets/Demos/Simple/Behaviours/SettingsBehaviour.cs
+++ b/Demo/Assets/Demos/Simple/Behaviours/SettingsBehaviour.cs
@@ -93,7 +93,7 @@ namespace Demos.Simple.Behaviours
             for (var i = 0; i < count; i++)
             {
                 var agent = Instantiate(this.agentPrefab, this.GetRandomPosition(), Quaternion.identity).GetComponent<AgentBehaviour>();
-                agent.GoapSet = this.goapSet.Set;
+                agent.GoapSet = this.goapSet.GoapSet;
             
                 this.SetDebug(agent.GetComponentInChildren<TextBehaviour>(), this.debug);
             

--- a/Package/Editor/CrashKonijn.Goap.Editor/Drawers/GoapSetDrawer.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/Drawers/GoapSetDrawer.cs
@@ -6,20 +6,20 @@ namespace CrashKonijn.Goap.Editor.Drawers
 {
     public class GoapSetDrawer : VisualElement
     {
-        public  GoapSetDrawer(IGoapSet set)
+        public  GoapSetDrawer(IGoapSet goapSet)
         {
             this.name = "goap-set";
             
             var card = new Card((card) =>
             {
-                card.Add(new Header(set.Id));
+                card.Add(new Header(goapSet.Id));
 
                 var root = new VisualElement();
 
                 card.schedule.Execute(() =>
                 {
                     root.Clear();
-                    root.Add(new Label($"Count: {set.Agents.All().Count}"));
+                    root.Add(new Label($"Count: {goapSet.Agents.All().Count}"));
                 }).Every(1000);
                 
                 card.Add(root);

--- a/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/NodeViewerEditorWindow.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/NodeViewerEditorWindow.cs
@@ -13,7 +13,7 @@ namespace CrashKonijn.Goap.Editor.NodeViewer
     public class NodeViewerEditorWindow : EditorWindow
     {
         private IGoapRunner runner;
-        private IGoapSet set;
+        private IGoapSet goapSet;
         private AgentBehaviour agent;
         private List<AgentBehaviour> agents;
         private VisualElement leftPanel;
@@ -126,7 +126,7 @@ namespace CrashKonijn.Goap.Editor.NodeViewer
 
         private VisualElement GetGraphElement()
         {
-            var graph = this.runner.GetGraph(this.set).ToPublic();
+            var graph = this.runner.GetGraph(this.goapSet).ToPublic();
 
             var element = new VisualElement();
             var widthOffset = 0f;
@@ -181,7 +181,7 @@ namespace CrashKonijn.Goap.Editor.NodeViewer
             list.selectionChanged += _ =>
             {
                 this.agent = this.agents[list.selectedIndex];
-                this.set = this.agent.GoapSet;
+                this.goapSet = this.agent.GoapSet;
                 this.RenderGraph();
             };
 #endif
@@ -198,7 +198,7 @@ namespace CrashKonijn.Goap.Editor.NodeViewer
             if (this.agent == null)
                 return;
             
-            if (!this.runner.Knows(this.set))
+            if (!this.runner.Knows(this.goapSet))
                 return;
 
             this.nodesDrawer = this.GetGraphElement();

--- a/Package/Editor/CrashKonijn.Goap.Editor/TypeDrawers/GoapRunnerEditor.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/TypeDrawers/GoapRunnerEditor.cs
@@ -1,4 +1,5 @@
-﻿using CrashKonijn.Goap.Behaviours;
+﻿using System.Linq;
+using CrashKonijn.Goap.Behaviours;
 using CrashKonijn.Goap.Editor.Drawers;
 using CrashKonijn.Goap.Editor.Elements;
 using UnityEditor;
@@ -18,7 +19,9 @@ namespace CrashKonijn.Goap.Editor.TypeDrawers
             
             root.styleSheets.Add(AssetDatabase.LoadAssetAtPath<StyleSheet>($"{GoapEditorSettings.BasePath}/Styles/Generic.uss"));
 
-            InspectorElement.FillDefaultInspector(root, this.serializedObject, this);
+            root.Add(new PropertyField(this.serializedObject.FindProperty("configInitializer")));
+            
+            this.RenderConfigFactories(root, runner);
             
             if (Application.isPlaying)
             {
@@ -30,6 +33,37 @@ namespace CrashKonijn.Goap.Editor.TypeDrawers
             }
             
             return root;
+        }
+
+        private void RenderConfigFactories(VisualElement root, GoapRunnerBehaviour runner)
+        {
+            // TODO: Remove at a later date
+#pragma warning disable CS0618
+            if (runner.setConfigFactories.Any())
+            {
+                var oldDataRoot = new VisualElement();
+                
+                oldDataRoot.Add(new PropertyField(this.serializedObject.FindProperty("setConfigFactories")));
+             
+                var button = new Button(() =>
+                {
+                    runner.goapSetConfigFactories.AddRange(runner.setConfigFactories);
+                    runner.setConfigFactories.Clear();
+                    EditorUtility.SetDirty(runner);
+                    oldDataRoot.Clear();
+                });
+                button.Add(new Label("Migrate data to goapSetConfigFactories"));
+
+                var helpBox = new HelpBox("", HelpBoxMessageType.Error);
+                helpBox.Add(button);
+                
+                oldDataRoot.Add(helpBox);
+
+                root.Add(oldDataRoot);
+            }
+#pragma warning restore CS0618
+            
+            root.Add(new PropertyField(this.serializedObject.FindProperty("goapSetConfigFactories")));
         }
     }
 }

--- a/Package/Editor/CrashKonijn.Goap.Editor/TypeDrawers/GoapRunnerEditor.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/TypeDrawers/GoapRunnerEditor.cs
@@ -22,10 +22,10 @@ namespace CrashKonijn.Goap.Editor.TypeDrawers
             
             if (Application.isPlaying)
             {
-                root.Add(new Header("Sets"));
-                foreach (var set in runner.Sets)
+                root.Add(new Header("Goap-Sets"));
+                foreach (var goapSet in runner.GoapSets)
                 {
-                    root.Add(new GoapSetDrawer(set));
+                    root.Add(new GoapSetDrawer(goapSet));
                 }
             }
             

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/AgentBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/AgentBehaviour.cs
@@ -41,7 +41,7 @@ namespace CrashKonijn.Goap.Behaviours
             this.Injector = new DataReferenceInjector(this);
             
             if (this.goapSetBehaviour != null)
-                this.GoapSet = this.goapSetBehaviour.Set;
+                this.GoapSet = this.goapSetBehaviour.GoapSet;
         }
 
         private void OnEnable()

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/GoapRunnerBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/GoapRunnerBehaviour.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using CrashKonijn.Goap.Classes;
 using CrashKonijn.Goap.Interfaces;
 using CrashKonijn.Goap.Resolver.Models;
@@ -16,22 +17,29 @@ namespace CrashKonijn.Goap.Behaviours
         public int RunCount { get; private set; }
 
         public GoapConfigInitializerBase configInitializer;
+
+        [System.Obsolete("'setConfigFactories' is deprecated, please use 'goapSetConfigFactories' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
+        [Header("Obsolete: please use 'GoapSetConfigFactories'")]
         public List<GoapSetFactoryBase> setConfigFactories = new();
+
+        public List<GoapSetFactoryBase> goapSetConfigFactories = new();
 
         private GoapConfig config;
 
         private void Awake()
         {
+            if(goapSetConfigFactories.Count is 0)
+                goapSetConfigFactories = setConfigFactories;
             this.config = GoapConfig.Default;
             this.runner = new Classes.Runners.GoapRunner();
             
             if (this.configInitializer != null)
                 this.configInitializer.InitConfig(this.config);
             
-            this.CreateSets();
+            this.CreateGoapSets();
         }
 
-        public void Register(IGoapSet set) => this.runner.Register(set);
+        public void Register(IGoapSet goapSet) => this.runner.Register(goapSet);
 
         private void Update()
         {
@@ -49,6 +57,7 @@ namespace CrashKonijn.Goap.Behaviours
             this.runner.Dispose();
         }
 
+        [System.Obsolete("'CreateSets()' is deprecated, please use 'CreateGoapSets()' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         private void CreateSets()
         {
             var setFactory = new GoapSetFactory(this.config);
@@ -59,10 +68,29 @@ namespace CrashKonijn.Goap.Behaviours
             });
         }
 
-        public Graph GetGraph(IGoapSet set) => this.runner.GetGraph(set);
-        public bool Knows(IGoapSet set) => this.runner.Knows(set);
+        private void CreateGoapSets()
+        {
+            var goapSetFactory = new GoapSetFactory(this.config);
+
+            this.goapSetConfigFactories.ForEach(factory =>
+            {
+                this.Register(goapSetFactory.Create(factory.Create()));
+            });
+        }
+
+
+        public Graph GetGraph(IGoapSet goapSet) => this.runner.GetGraph(goapSet);
+        public bool Knows(IGoapSet goapSet) => this.runner.Knows(goapSet);
         public IMonoAgent[] Agents => this.runner.Agents;
+
+        [System.Obsolete("'Sets' is deprecated, please use 'GoapSets' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         public IGoapSet[] Sets => this.runner.Sets;
+
+        public IGoapSet[] GoapSets => this.runner.GoapSets;
+
+        [System.Obsolete("'GetSet' is deprecated, please use 'GoapSets' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         public IGoapSet GetSet(string id) => this.runner.GetSet(id);
+
+        public IGoapSet GetGoapSet(string id) => this.runner.GetGoapSet(id);
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/GoapRunnerBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/GoapRunnerBehaviour.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using CrashKonijn.Goap.Classes;
 using CrashKonijn.Goap.Interfaces;
 using CrashKonijn.Goap.Resolver.Models;
@@ -18,7 +19,7 @@ namespace CrashKonijn.Goap.Behaviours
 
         public GoapConfigInitializerBase configInitializer;
 
-        [System.Obsolete("'setConfigFactories' is deprecated, please use 'goapSetConfigFactories' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
+        [Obsolete("'setConfigFactories' is deprecated, please use 'goapSetConfigFactories' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         [Header("Obsolete: please use 'GoapSetConfigFactories'")]
         public List<GoapSetFactoryBase> setConfigFactories = new();
 
@@ -28,8 +29,6 @@ namespace CrashKonijn.Goap.Behaviours
 
         private void Awake()
         {
-            if(goapSetConfigFactories.Count is 0)
-                goapSetConfigFactories = setConfigFactories;
             this.config = GoapConfig.Default;
             this.runner = new Classes.Runners.GoapRunner();
             
@@ -57,19 +56,16 @@ namespace CrashKonijn.Goap.Behaviours
             this.runner.Dispose();
         }
 
-        [System.Obsolete("'CreateSets()' is deprecated, please use 'CreateGoapSets()' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
-        private void CreateSets()
-        {
-            var setFactory = new GoapSetFactory(this.config);
-            
-            this.setConfigFactories.ForEach(factory =>
-            {
-                this.Register(setFactory.Create(factory.Create()));
-            });
-        }
-
         private void CreateGoapSets()
         {
+#pragma warning disable CS0618
+            if (this.setConfigFactories.Any())
+            {
+                Debug.LogError("setConfigFactory is obsolete. Please move its data to the goapSetConfigFactories using the editor.");
+                this.goapSetConfigFactories.AddRange(this.setConfigFactories);
+            }
+#pragma warning restore CS0618
+            
             var goapSetFactory = new GoapSetFactory(this.config);
 
             this.goapSetConfigFactories.ForEach(factory =>
@@ -82,12 +78,12 @@ namespace CrashKonijn.Goap.Behaviours
         public bool Knows(IGoapSet goapSet) => this.runner.Knows(goapSet);
         public IMonoAgent[] Agents => this.runner.Agents;
 
-        [System.Obsolete("'Sets' is deprecated, please use 'GoapSets' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
+        [Obsolete("'Sets' is deprecated, please use 'GoapSets' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         public IGoapSet[] Sets => this.runner.Sets;
 
         public IGoapSet[] GoapSets => this.runner.GoapSets;
 
-        [System.Obsolete("'GetSet' is deprecated, please use 'GoapSets' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
+        [Obsolete("'GetSet' is deprecated, please use 'GoapSets' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         public IGoapSet GetSet(string id) => this.runner.GetSet(id);
 
         public IGoapSet GetGoapSet(string id) => this.runner.GetGoapSet(id);

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/GoapRunnerBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/GoapRunnerBehaviour.cs
@@ -78,7 +78,6 @@ namespace CrashKonijn.Goap.Behaviours
             });
         }
 
-
         public Graph GetGraph(IGoapSet goapSet) => this.runner.GetGraph(goapSet);
         public bool Knows(IGoapSet goapSet) => this.runner.Knows(goapSet);
         public IMonoAgent[] Agents => this.runner.Agents;

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/GoapSetBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/GoapSetBehaviour.cs
@@ -14,15 +14,18 @@ namespace CrashKonijn.Goap.Behaviours
         [SerializeField]
         private GoapRunnerBehaviour runner;
 
+        [System.Obsolete("'Set' is deprecated, please use 'GoapSet' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         public IGoapSet Set { get; private set; }
+
+        public IGoapSet GoapSet { get; private set; }
 
         private void Awake()
         {
-            var set = new GoapSetFactory(GoapConfig.Default).Create(this.config);
+            var goapSet = new GoapSetFactory(GoapConfig.Default).Create(this.config);
 
-            this.runner.Register(set);
+            this.runner.Register(goapSet);
             
-            this.Set = set;
+            this.GoapSet = goapSet;
         }
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Builders/GoapSetBuilder.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Builders/GoapSetBuilder.cs
@@ -7,7 +7,7 @@ namespace CrashKonijn.Goap.Classes.Builders
 {
     public class GoapSetBuilder
     {
-        private readonly GoapSetConfig set;
+        private readonly GoapSetConfig goapSetConfig;
 
         private readonly List<ActionBuilder> actionBuilders = new();
         private readonly List<GoalBuilder> goalBuilders = new();
@@ -18,7 +18,7 @@ namespace CrashKonijn.Goap.Classes.Builders
 
         public GoapSetBuilder(string name)
         {
-            this.set = new GoapSetConfig(name);
+            this.goapSetConfig = new GoapSetConfig(name);
         }
         
         public ActionBuilder AddAction<TAction>()
@@ -68,12 +68,12 @@ namespace CrashKonijn.Goap.Classes.Builders
         
         public GoapSetConfig Build()
         {
-            this.set.Actions = this.actionBuilders.Select(x => x.Build()).ToList();
-            this.set.Goals = this.goalBuilders.Select(x => x.Build()).ToList();
-            this.set.TargetSensors = this.targetSensorBuilders.Select(x => x.Build()).ToList();
-            this.set.WorldSensors = this.worldSensorBuilders.Select(x => x.Build()).ToList();
+            this.goapSetConfig.Actions = this.actionBuilders.Select(x => x.Build()).ToList();
+            this.goapSetConfig.Goals = this.goalBuilders.Select(x => x.Build()).ToList();
+            this.goapSetConfig.TargetSensors = this.targetSensorBuilders.Select(x => x.Build()).ToList();
+            this.goapSetConfig.WorldSensors = this.worldSensorBuilders.Select(x => x.Build()).ToList();
             
-            return this.set;
+            return this.goapSetConfig;
         }
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Runners/GoapRunner.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Runners/GoapRunner.cs
@@ -9,19 +9,19 @@ namespace CrashKonijn.Goap.Classes.Runners
 {
     public class GoapRunner : IGoapRunner
     {
-        private Dictionary<IGoapSet, GoapSetJobRunner> sets = new();
+        private Dictionary<IGoapSet, GoapSetJobRunner> goapSets = new();
         private Stopwatch stopwatch = new();
 
         public float RunTime { get; private set; }
         public float CompleteTime { get; private set; }
 
-        public void Register(IGoapSet set) => this.sets.Add(set, new GoapSetJobRunner(set, new GraphResolver(set.GetAllNodes().ToArray(), set.GoapConfig.KeyResolver)));
+        public void Register(IGoapSet goapSet) => this.goapSets.Add(goapSet, new GoapSetJobRunner(goapSet, new GraphResolver(goapSet.GetAllNodes().ToArray(), goapSet.GoapConfig.KeyResolver)));
 
         public void Run()
         {
             this.stopwatch.Restart();
             
-            foreach (var runner in this.sets.Values)
+            foreach (var runner in this.goapSets.Values)
             {
                 runner.Run();
             }
@@ -38,7 +38,7 @@ namespace CrashKonijn.Goap.Classes.Runners
         {
             this.stopwatch.Restart();
             
-            foreach (var runner in this.sets.Values)
+            foreach (var runner in this.goapSets.Values)
             {
                 runner.Complete();
             }
@@ -48,7 +48,7 @@ namespace CrashKonijn.Goap.Classes.Runners
 
         public void Dispose()
         {
-            foreach (var runner in this.sets.Values)
+            foreach (var runner in this.goapSets.Values)
             {
                 runner.Dispose();
             }
@@ -61,11 +61,16 @@ namespace CrashKonijn.Goap.Classes.Runners
             return (float) ((double)this.stopwatch.ElapsedTicks / Stopwatch.Frequency * 1000);
         }
 
-        public Graph GetGraph(IGoapSet set) => this.sets[set].GetGraph();
-        public bool Knows(IGoapSet set) => this.sets.ContainsKey(set);
-        public IMonoAgent[] Agents => this.sets.Keys.SelectMany(x => x.Agents.All()).ToArray();
-        public IGoapSet[] Sets => this.sets.Keys.ToArray();
+        public Graph GetGraph(IGoapSet goapSet) => this.goapSets[goapSet].GetGraph();
+        public bool Knows(IGoapSet goapSet) => this.goapSets.ContainsKey(goapSet);
+        public IMonoAgent[] Agents => this.goapSets.Keys.SelectMany(x => x.Agents.All()).ToArray();
+        
+        [System.Obsolete("'Sets' is deprecated, please use 'GoapSets' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
+        public IGoapSet[] Sets => this.goapSets.Keys.ToArray();
 
+        public IGoapSet[] GoapSets => this.goapSets.Keys.ToArray();
+
+        [System.Obsolete("'GetSet' is deprecated, please use 'GetGoapSet' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         public IGoapSet GetSet(string id)
         {
             var set = this.Sets.FirstOrDefault(x => x.Id == id);
@@ -76,6 +81,16 @@ namespace CrashKonijn.Goap.Classes.Runners
             return set;
         }
 
-        public int QueueCount => this.sets.Keys.Sum(x => x.Agents.GetQueueCount());
+        public IGoapSet GetGoapSet(string id)
+        {
+            var goapSet = this.GoapSets.FirstOrDefault(x => x.Id == id);
+
+            if (goapSet == null)
+                throw new KeyNotFoundException($"No goapSet with id {id} found");
+
+            return goapSet;
+        }
+
+        public int QueueCount => this.goapSets.Keys.Sum(x => x.Agents.GetQueueCount());
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionClassTypeValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionClassTypeValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class ActionClassTypeValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var empty = config.Actions.Where(x => string.IsNullOrEmpty(x.ClassType)).ToArray();
+            var empty = goapSetConfig.Actions.Where(x => string.IsNullOrEmpty(x.ClassType)).ToArray();
             
             if (!empty.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionConditionKeyValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionConditionKeyValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class ActionConditionKeyValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            foreach (var configAction in config.Actions)
+            foreach (var configAction in goapSetConfig.Actions)
             {
                 var missing = configAction.Conditions.Where(x => x.WorldKey == null).ToArray();
                 

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionEffectKeyValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionEffectKeyValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class ActionEffectKeyValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            foreach (var configAction in config.Actions)
+            foreach (var configAction in goapSetConfig.Actions)
             {
                 var missing = configAction.Effects.Where(x => x.WorldKey == null).ToArray();
                 

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionEffectsValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionEffectsValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class ActionEffectsValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var missing = config.Actions.Where(x => !x.Effects.Any()).ToArray();
+            var missing = goapSetConfig.Actions.Where(x => !x.Effects.Any()).ToArray();
             
             if (!missing.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionTargetValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/ActionTargetValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class ActionTargetValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var missing = config.Actions.Where(x => x.Target == null).ToArray();
+            var missing = goapSetConfig.Actions.Where(x => x.Target == null).ToArray();
             
             if (!missing.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/Extensions.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/Extensions.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public static class Extensions
     {
-        public static IWorldKey[] GetWorldKeys(this IGoapSetConfig config)
+        public static IWorldKey[] GetWorldKeys(this IGoapSetConfig goapSetConfig)
         {
-            return config.Actions
+            return goapSetConfig.Actions
                 .SelectMany((action) =>
                 {
                     return action.Conditions
@@ -19,9 +19,9 @@ namespace CrashKonijn.Goap.Classes.Validators
                 .ToArray();
         }
         
-        public static ITargetKey[] GetTargetKeys(this IGoapSetConfig config)
+        public static ITargetKey[] GetTargetKeys(this IGoapSetConfig goapSetConfig)
         {
-            return config.Actions
+            return goapSetConfig.Actions
                 .Where(x => x.Target != null)
                 .Select(x => x.Target)
                 .Distinct()

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/GoalClassTypeValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/GoalClassTypeValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class GoalClassTypeValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var empty = config.Goals.Where(x => string.IsNullOrEmpty(x.ClassType)).ToArray();
+            var empty = goapSetConfig.Goals.Where(x => string.IsNullOrEmpty(x.ClassType)).ToArray();
             
             if (!empty.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/GoalConditionKeyValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/GoalConditionKeyValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class GoalConditionKeyValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            foreach (var configGoal in config.Goals)
+            foreach (var configGoal in goapSetConfig.Goals)
             {
                 var missing = configGoal.Conditions.Where(x => x.WorldKey == null).ToArray();
                 

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/GoalConditionsValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/GoalConditionsValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class GoalConditionsValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var missing = config.Goals.Where(x => !x.Conditions.Any()).ToArray();
+            var missing = goapSetConfig.Goals.Where(x => !x.Conditions.Any()).ToArray();
             
             if (!missing.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/GoapSetConfigValidatorRunner.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/GoapSetConfigValidatorRunner.cs
@@ -25,13 +25,13 @@ namespace CrashKonijn.Goap.Classes.Validators
             new TargetSensorKeyValidator()
         };
         
-        public ValidationResults Validate(IGoapSetConfig config)
+        public ValidationResults Validate(IGoapSetConfig goapSetConfig)
         {
-            var results = new ValidationResults(config.Name);
+            var results = new ValidationResults(goapSetConfig.Name);
             
             foreach (var validator in this.validators)
             {
-                validator.Validate(config, results);
+                validator.Validate(goapSetConfig, results);
             }
 
             return results;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/TargetKeySensorsValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/TargetKeySensorsValidator.cs
@@ -6,10 +6,10 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class TargetKeySensorsValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var required = config.GetTargetKeys();
-            var provided = config.TargetSensors
+            var required = goapSetConfig.GetTargetKeys();
+            var provided = goapSetConfig.TargetSensors
                 .Where(x => x.Key != null)
                 .Select(x => x.Key)
                 .ToArray();

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/TargetSensorClassTypeValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/TargetSensorClassTypeValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class TargetSensorClassTypeValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var empty = config.TargetSensors.Where(x => string.IsNullOrEmpty(x.ClassType)).ToArray();
+            var empty = goapSetConfig.TargetSensors.Where(x => string.IsNullOrEmpty(x.ClassType)).ToArray();
             
             if (!empty.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/TargetSensorKeyValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/TargetSensorKeyValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class TargetSensorKeyValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var missing = config.TargetSensors.Where(x => x.Key == null).ToArray();
+            var missing = goapSetConfig.TargetSensors.Where(x => x.Key == null).ToArray();
             
             if (!missing.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/WorldKeySensorsValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/WorldKeySensorsValidator.cs
@@ -6,10 +6,10 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class WorldKeySensorsValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var required = config.GetWorldKeys();
-            var provided = config.WorldSensors
+            var required = goapSetConfig.GetWorldKeys();
+            var provided = goapSetConfig.WorldSensors
                 .Where(x => x.Key != null)
                 .Select(x => x.Key)
                 .ToArray();

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/WorldSensorClassTypeValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/WorldSensorClassTypeValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class WorldSensorClassTypeValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var empty = config.WorldSensors.Where(x => string.IsNullOrEmpty(x.ClassType)).ToArray();
+            var empty = goapSetConfig.WorldSensors.Where(x => string.IsNullOrEmpty(x.ClassType)).ToArray();
             
             if (!empty.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Validators/WorldSensorKeyValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Validators/WorldSensorKeyValidator.cs
@@ -6,9 +6,9 @@ namespace CrashKonijn.Goap.Classes.Validators
 {
     public class WorldSensorKeyValidator : IValidator<IGoapSetConfig>
     {
-        public void Validate(IGoapSetConfig config, ValidationResults results)
+        public void Validate(IGoapSetConfig goapSetConfig, ValidationResults results)
         {
-            var missing = config.WorldSensors.Where(x => x.Key == null).ToArray();
+            var missing = goapSetConfig.WorldSensors.Where(x => x.Key == null).ToArray();
             
             if (!missing.Any())
                 return;

--- a/Package/Runtime/CrashKonijn.Goap/Interfaces/IGoapRunner.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Interfaces/IGoapRunner.cs
@@ -5,11 +5,19 @@ namespace CrashKonijn.Goap.Interfaces
 {
     public interface IGoapRunner
     {
-        void Register(IGoapSet set);
-        Graph GetGraph(IGoapSet set);
-        bool Knows(IGoapSet set);
+        void Register(IGoapSet goapSet);
+        Graph GetGraph(IGoapSet goapSet);
+        bool Knows(IGoapSet goapSet);
         IMonoAgent[] Agents { get; }
+
+        [System.Obsolete("'Sets' is deprecated, please use 'GoapSets' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         IGoapSet[] Sets { get; }
+
+        IGoapSet[] GoapSets { get; }
+
+        [System.Obsolete("'GetSet' is deprecated, please use 'GetGoapSet' instead.   Exact same functionality, name changed to mitigate confusion with the word 'set' which could have many meanings.")]
         IGoapSet GetSet(string id);
+
+        IGoapSet GetGoapSet(string id);
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap/Interfaces/IGoapSetConfigValidatorRunner.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Interfaces/IGoapSetConfigValidatorRunner.cs
@@ -5,6 +5,6 @@ namespace CrashKonijn.Goap.Interfaces
 {
     public interface IGoapSetConfigValidatorRunner
     {
-        ValidationResults Validate(IGoapSetConfig config);
+        ValidationResults Validate(IGoapSetConfig goapSetConfig);
     }
 }


### PR DESCRIPTION
Major name refactor to change all derivatives of 'Set' to 'GoapSet'. This to mitigate possible confusion around the different meanings of the word 'set'. Backward compatibility has been preserved via the use of 'obsolete' on changed public properties and methods.

**WARNING!**
This change is 99% okay, apart from one issue.  The manual 'wiring up' of `GoapSetConfigFactories` within the `GoapRunnerBehaviour` component is problematic.

As you can see in this screenshot of the editor, I now have two arrays of AgentSetConfigFactories - `SetConfigFactories`, which I have labeled as obsolete, and `GoapSetConfigFactories`.  In the awake method of `GoapRunnerBehaviour`, I have made a check to see if the `goapSetConfigFactories` collection is empty, and if so, set it to equal the now obsolete `setConfigFactories`.

But this does mean we now have two collections in the UI, which isn't right.

I do not know how to handle obsolescence of a public property within a component. 

![image](https://github.com/crashkonijn/GOAP/assets/16468333/b49f8088-dc35-41bd-ab9a-387a04bac744)