### PR TITLE
Introduced 'Freeform Debug Info'

### DIFF
--- a/Demo/Assets/Demos/Complex/Behaviours/ComplexAgentBrain.cs
+++ b/Demo/Assets/Demos/Complex/Behaviours/ComplexAgentBrain.cs
@@ -4,6 +4,7 @@ using Demos.Complex.Classes.Items;
 using Demos.Complex.Goals;
 using Demos.Shared.Behaviours;
 using Demos.Shared.Goals;
+using System.Collections;
 using UnityEngine;
 
 namespace Demos.Complex.Behaviours
@@ -15,6 +16,7 @@ namespace Demos.Complex.Behaviours
         private HungerBehaviour hunger;
         private ItemCollection itemCollection;
         private ComplexInventoryBehaviour inventory;
+        private float fastTickSeconds = 0.2f; //refresh frequency of Debug Information
 
         private void Awake()
         {
@@ -22,6 +24,8 @@ namespace Demos.Complex.Behaviours
             this.hunger = this.GetComponent<HungerBehaviour>();
             this.inventory = this.GetComponent<ComplexInventoryBehaviour>();
             this.itemCollection = FindObjectOfType<ItemCollection>();
+
+            StartCoroutine(TriggerFastTick());
         }
 
         private void OnEnable()
@@ -157,6 +161,37 @@ namespace Demos.Complex.Behaviours
             }
             
             this.agent.SetGoal<WanderGoal>(false);
+        }
+        private void GenerateNodeViewerGenericDebugOutput()
+        {
+            string nodeViewerFreeformDebugOutput = string.Empty;
+
+            switch (this.agentType)
+            {
+                case AgentType.Miner:
+                    nodeViewerFreeformDebugOutput = $" - Hunger: {this.hunger.hunger}\n - Define any Miner info here\n";
+                    break;
+                case AgentType.WoodCutter:
+                    nodeViewerFreeformDebugOutput = $" - Hunger: {this.hunger.hunger}\n - Define any WoodCutter info here\n";
+                    break;
+                case AgentType.Smith:
+                    nodeViewerFreeformDebugOutput = $" - Hunger: {this.hunger.hunger}\n - Define any Smith info here\n";
+                    break;
+                case AgentType.Cleaner:
+                    nodeViewerFreeformDebugOutput = $" - Hunger: {this.hunger.hunger}\n - Define any Cleaner info here\n";
+                    break;
+            }
+
+            this.agent.NodeViewerFreeformDebugOutput = nodeViewerFreeformDebugOutput;
+        }
+
+        IEnumerator TriggerFastTick()
+        {
+            while (true)
+            {
+                GenerateNodeViewerGenericDebugOutput();
+                yield return new WaitForSeconds(this.fastTickSeconds);
+            }
         }
 
         public enum AgentType

--- a/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/Drawers/AgentDataDrawer.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/Drawers/AgentDataDrawer.cs
@@ -24,7 +24,6 @@ namespace CrashKonijn.Goap.Editor.NodeViewer.Drawers
                         card.Add(new Label("\n<b>Freeform Debug Data:</b>"));
                         card.Add(new Label(agent.NodeViewerFreeformDebugOutput));
                     }
-
                 }).Every(500);
             });
             

--- a/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/Drawers/AgentDataDrawer.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/Drawers/AgentDataDrawer.cs
@@ -18,6 +18,13 @@ namespace CrashKonijn.Goap.Editor.NodeViewer.Drawers
                     card.Clear();
                     card.Add(new Header("Agent Data"));
                     card.Add(new ObjectDrawer(agent.CurrentActionData));
+
+                    if (!string.IsNullOrEmpty(agent.NodeViewerFreeformDebugOutput))
+                    {
+                        card.Add(new Label("\n<b>Freeform Debug Data:</b>"));
+                        card.Add(new Label(agent.NodeViewerFreeformDebugOutput));
+                    }
+
                 }).Every(500);
             });
             

--- a/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/Drawers/NodeDrawer.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/Drawers/NodeDrawer.cs
@@ -83,8 +83,6 @@ namespace CrashKonijn.Goap.Editor.NodeViewer.Drawers
             var effects = action.Effects.Select(x => this.GetText(x as IEffect));
 
             var cost = action.GetCost(agent as IMonoAgent, agent.Injector);
-
-
             
             var target = agent.WorldData.GetTarget(action);
 

--- a/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/Drawers/NodeDrawer.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/Drawers/NodeDrawer.cs
@@ -83,6 +83,8 @@ namespace CrashKonijn.Goap.Editor.NodeViewer.Drawers
             var effects = action.Effects.Select(x => this.GetText(x as IEffect));
 
             var cost = action.GetCost(agent as IMonoAgent, agent.Injector);
+
+
             
             var target = agent.WorldData.GetTarget(action);
 

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/AgentBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/AgentBehaviour.cs
@@ -9,6 +9,8 @@ namespace CrashKonijn.Goap.Behaviours
 {
     public class AgentBehaviour : MonoBehaviour, IMonoAgent
     {
+        public string NodeViewerFreeformDebugOutput { get; set; }
+
         public GoapSetBehaviour goapSetBehaviour;
 
         public AgentState State { get; private set; } = AgentState.NoAction;

--- a/Package/Runtime/CrashKonijn.Goap/Interfaces/IAgent.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Interfaces/IAgent.cs
@@ -6,6 +6,8 @@ namespace CrashKonijn.Goap.Interfaces
 {
     public interface IAgent
     {
+        string NodeViewerFreeformDebugOutput { get; set; }
+
         AgentState State { get; }
         IGoapSet GoapSet { get; }
         IGoalBase CurrentGoal { get; }


### PR DESCRIPTION
Introduced 'Freeform Debug Info' - intended as a mechanism for developers to include their own adhoc debug data, for inclusion into the GOAP-NodeViewer.

The intent is to allow developers to drop in whatever adhoc agent-specific data they would like & have it displayed inline with the existing Node Viewer.

This PR is based upon the developer building their own string of debug info - there may be a more modular way of approaching this, but as a relatively quick way to get a desired result, this works.

Changes include:

* private string in `AgentBehaviour` to store the content of the user-created-message (including update to interface)
* revision of `AgentDataDrawer` to draw a new minor-heading and the user-create-message
* revision of the `ComplexAgentBrain` in demo, to show how developers could add in their own custom debug messages. 

The change to `ComplexAgentBrain` uses a coroutine to reduce the update frequency (i.e. it is not on the update loop) - this may be a candidate for a refactor if this isn't in-keeping with any preferred coding style for scheduled tasks?

![image](https://github.com/crashkonijn/GOAP/assets/16468333/5ae58b6b-6a7c-43e9-8bbb-eb36c1fd8268)


