### PR TITLE
Fixed: Jobs leaking when quitting play

### DIFF
--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Actions/HaulItemAction.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Actions/HaulItemAction.cs
@@ -28,6 +28,9 @@ namespace Demos.Complex.Actions
         public override void Start(IMonoAgent agent, Data data)
         {
             var item = this.itemCollection.Closest(agent.transform.position, false, false, false);
+            
+            if (item is null)
+                return;
 
             item.Claim();
             
@@ -38,6 +41,9 @@ namespace Demos.Complex.Actions
 
         public override ActionRunState Perform(IMonoAgent agent, Data data, ActionContext context)
         {
+            if (data.Item is null)
+                return ActionRunState.Stop;
+            
             switch (data.State)
             {
                 case State.MovingToItem:

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Runners/GoapRunner.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Runners/GoapRunner.cs
@@ -30,6 +30,9 @@ namespace CrashKonijn.Goap.Classes.Runners
                         
             foreach (var agent in this.Agents)
             {
+                if (agent.IsNull())
+                    continue;
+                
                 agent.Run();
             }
         }

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Runners/GoapSetJobRunner.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Runners/GoapSetJobRunner.cs
@@ -128,6 +128,10 @@ namespace CrashKonijn.Goap.Classes.Runners
             foreach (var resolveHandle in this.resolveHandles)
             {
                 var result = resolveHandle.Handle.Complete().OfType<IActionBase>().ToList();
+
+                if (resolveHandle.Agent.IsNull())
+                    continue;
+                
                 var action = result.FirstOrDefault();
                 
                 if (action is null)
@@ -138,6 +142,8 @@ namespace CrashKonijn.Goap.Classes.Runners
                 
                 resolveHandle.Agent.SetAction(action, result, resolveHandle.Agent.WorldData.GetTarget(action));
             }
+            
+            this.resolveHandles.Clear();
         }
 
         public void Dispose()


### PR DESCRIPTION
- Fixed: Jobs not disposing correctly after exiting play
- Fixed: Complex example sometimes throwing null-ref, especially with large number of agents.

Fixes: #60