### PR TITLE
DebugGraph conflict fix

### DIFF
--- a/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/NodeViewerEditorWindow.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/NodeViewerEditorWindow.cs
@@ -149,7 +149,7 @@ namespace CrashKonijn.Goap.Editor.NodeViewer
 
             foreach (var graphRootNode in graph.RootNodes.Values)
             {
-                var debugGraph = new DebugGraph(graph).GetGraph(graphRootNode);
+                var debugGraph = new CrashKonijn.Goap.Editor.Classes.DebugGraph(graph).GetGraph(graphRootNode);
                 var drawer = new NodesDrawer(debugGraph, this.agent);
                 
                 drawer.transform.position = new Vector3(widthOffset, 0f);

--- a/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/NodeViewerEditorWindow.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/NodeViewer/NodeViewerEditorWindow.cs
@@ -149,6 +149,7 @@ namespace CrashKonijn.Goap.Editor.NodeViewer
 
             foreach (var graphRootNode in graph.RootNodes.Values)
             {
+                // Fully qualified namespace to prevent collision with the Squiggle package. Fixes #126.
                 var debugGraph = new CrashKonijn.Goap.Editor.Classes.DebugGraph(graph).GetGraph(graphRootNode);
                 var drawer = new NodesDrawer(debugGraph, this.agent);
                 


### PR DESCRIPTION
* DebugGraph conflicts with non-namespaced Unity Packages like Squiggle

Fixes: #126