### PR TITLE
Change: renamed in and out of range

### DIFF
--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Behaviours/AgentMoveBehaviour.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Behaviours/AgentMoveBehaviour.cs
@@ -19,14 +19,14 @@ namespace CrashKonijn.Goap.Demos.Complex.Behaviours
         {
             this.agent.Events.OnTargetInRange += this.OnTargetInRange;
             this.agent.Events.OnTargetChanged += this.OnTargetChanged;
-            this.agent.Events.OnTargetOutOfRange += this.OnTargetOutOfRange;
+            this.agent.Events.OnTargetNotInRange += this.TargetNotInRange;
         }
 
         private void OnDisable()
         {
             this.agent.Events.OnTargetInRange -= this.OnTargetInRange;
             this.agent.Events.OnTargetChanged -= this.OnTargetChanged;
-            this.agent.Events.OnTargetOutOfRange -= this.OnTargetOutOfRange;
+            this.agent.Events.OnTargetNotInRange -= this.TargetNotInRange;
         }
 
         private void OnTargetInRange(ITarget target)
@@ -40,7 +40,7 @@ namespace CrashKonijn.Goap.Demos.Complex.Behaviours
             this.shouldMove = !inRange;
         }
 
-        private void OnTargetOutOfRange(ITarget target)
+        private void TargetNotInRange(ITarget target)
         {
             this.shouldMove = true;
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Shared/Behaviours/AgentMoveBehaviour.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Shared/Behaviours/AgentMoveBehaviour.cs
@@ -20,14 +20,14 @@ namespace Demos.Shared.Behaviours
         {
             this.agent.Events.OnTargetInRange += this.OnTargetInRange;
             this.agent.Events.OnTargetChanged += this.OnTargetChanged;
-            this.agent.Events.OnTargetOutOfRange += this.OnTargetOutOfRange;
+            this.agent.Events.OnTargetNotInRange += this.TargetNotInRange;
         }
 
         private void OnDisable()
         {
             this.agent.Events.OnTargetInRange -= this.OnTargetInRange;
             this.agent.Events.OnTargetChanged -= this.OnTargetChanged;
-            this.agent.Events.OnTargetOutOfRange -= this.OnTargetOutOfRange;
+            this.agent.Events.OnTargetNotInRange -= this.TargetNotInRange;
         }
 
         private void OnTargetInRange(ITarget target)
@@ -41,7 +41,7 @@ namespace Demos.Shared.Behaviours
             this.shouldMove = !inRange;
         }
 
-        private void OnTargetOutOfRange(ITarget target)
+        private void TargetNotInRange(ITarget target)
         {
             this.shouldMove = true;
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Behaviours/AgentMoveBehaviour.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Behaviours/AgentMoveBehaviour.cs
@@ -19,14 +19,14 @@ namespace CrashKonijn.Goap.Demos.Simple.Behaviours
         {
             this.agent.Events.OnTargetInRange += this.OnTargetInRange;
             this.agent.Events.OnTargetChanged += this.OnTargetChanged;
-            this.agent.Events.OnTargetOutOfRange += this.OnTargetOutOfRange;
+            this.agent.Events.OnTargetNotInRange += this.TargetNotInRange;
         }
 
         private void OnDisable()
         {
             this.agent.Events.OnTargetInRange -= this.OnTargetInRange;
             this.agent.Events.OnTargetChanged -= this.OnTargetChanged;
-            this.agent.Events.OnTargetOutOfRange -= this.OnTargetOutOfRange;
+            this.agent.Events.OnTargetNotInRange -= this.TargetNotInRange;
         }
 
         private void OnTargetInRange(ITarget target)
@@ -40,7 +40,7 @@ namespace CrashKonijn.Goap.Demos.Simple.Behaviours
             this.shouldMove = !inRange;
         }
 
-        private void OnTargetOutOfRange(ITarget target)
+        private void TargetNotInRange(ITarget target)
         {
             this.shouldMove = true;
         }

--- a/Package/Runtime/CrashKonijn.Goap.Core/Enums/AgentMoveState.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Core/Enums/AgentMoveState.cs
@@ -4,6 +4,6 @@
     {
         Idle,
         InRange,
-        OutOfRange,
+        NotInRange,
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IActionConfig.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IActionConfig.cs
@@ -6,7 +6,7 @@ namespace CrashKonijn.Goap.Core.Interfaces
     {
         int BaseCost { get; }
         ITargetKey Target { get; }
-        float InRange { get; }
+        float StoppingDistance { get; }
         bool RequiresTarget { get; }
         ICondition[] Conditions { get; }
         IEffect[] Effects { get; }

--- a/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IAgentEvents.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IAgentEvents.cs
@@ -28,8 +28,8 @@
         event TargetDelegate OnTargetInRange;
         void TargetInRange(ITarget target);
         
-        event TargetDelegate OnTargetOutOfRange;
-        void TargetOutOfRange(ITarget target);
+        event TargetDelegate OnTargetNotInRange;
+        void TargetNotInRange(ITarget target);
         
         event TargetRangeDelegate OnTargetChanged;
         void TargetChanged(ITarget target, bool inRange);

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/ActionBase.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/ActionBase.cs
@@ -114,7 +114,7 @@ namespace CrashKonijn.Goap.Behaviours
         [Obsolete("Please use the IsInRange method")]
         public virtual float GetInRange(IMonoAgent agent, IActionData data)
         {
-            return this.Config.InRange;
+            return this.Config.StoppingDistance;
         }
         
         public virtual bool IsInRange(IMonoAgent agent, float distance, IActionData data, IComponentReference references)

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/ActionRunner.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/ActionRunner.cs
@@ -58,7 +58,7 @@ namespace CrashKonijn.Goap.Behaviours
             }
                 
             this.proxy.SetState(AgentState.MovingWhilePerformingAction);
-            this.proxy.SetMoveState(AgentMoveState.OutOfRange);
+            this.proxy.SetMoveState(AgentMoveState.NotInRange);
             this.Move();
             this.PerformAction();
         }
@@ -74,7 +74,7 @@ namespace CrashKonijn.Goap.Behaviours
             }
 
             this.proxy.SetState(AgentState.MovingToTarget);
-            this.proxy.SetMoveState(AgentMoveState.OutOfRange);
+            this.proxy.SetMoveState(AgentMoveState.NotInRange);
             this.Move();
         }
 

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/AgentBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/AgentBehaviour.cs
@@ -132,8 +132,8 @@ namespace CrashKonijn.Goap.Behaviours
                 case AgentMoveState.InRange:
                     this.Events.TargetInRange(this.CurrentTarget);
                     break;
-                case AgentMoveState.OutOfRange:
-                    this.Events.TargetOutOfRange(this.CurrentTarget);
+                case AgentMoveState.NotInRange:
+                    this.Events.TargetNotInRange(this.CurrentTarget);
                     break;
             }
         }

--- a/Package/Runtime/CrashKonijn.Goap/Behaviours/AgentEvents.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Behaviours/AgentEvents.cs
@@ -67,10 +67,10 @@ namespace CrashKonijn.Goap.Behaviours
             this.OnTargetInRange?.Invoke(target);
         }
 
-        public event TargetDelegate OnTargetOutOfRange;
-        public void TargetOutOfRange(ITarget target)
+        public event TargetDelegate OnTargetNotInRange;
+        public void TargetNotInRange(ITarget target)
         {
-            this.OnTargetOutOfRange?.Invoke(target);
+            this.OnTargetNotInRange?.Invoke(target);
         }
 
         public event TargetRangeDelegate OnTargetChanged;

--- a/Package/Runtime/CrashKonijn.Goap/Classes/Builders/ActionBuilder.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Classes/Builders/ActionBuilder.cs
@@ -29,7 +29,7 @@ namespace CrashKonijn.Goap.Classes.Builders
                 Name = actionType.Name,
                 ClassType = actionType.AssemblyQualifiedName,
                 BaseCost = 1,
-                InRange = 0.5f,
+                StoppingDistance = 0.5f,
                 RequiresTarget = true,
             };
         }
@@ -53,9 +53,9 @@ namespace CrashKonijn.Goap.Classes.Builders
             return this;
         }
         
-        public ActionBuilder SetInRange(float inRange)
+        public ActionBuilder SetStoppingDistance(float inRange)
         {
-            this.config.InRange = inRange;
+            this.config.StoppingDistance = inRange;
             return this;
         }
         

--- a/Package/Runtime/CrashKonijn.Goap/Configs/ActionConfig.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Configs/ActionConfig.cs
@@ -10,7 +10,7 @@ namespace CrashKonijn.Goap.Configs
         public IActionProperties Properties { get; set; }
         public int BaseCost { get; set; }
         public ITargetKey Target { get; set; }
-        public float InRange { get; set; }
+        public float StoppingDistance { get; set; }
         public bool RequiresTarget { get; set; }
         public ICondition[] Conditions { get; set; }
         public IEffect[] Effects { get; set; }

--- a/Package/Runtime/CrashKonijn.Goap/Scriptables/ActionConfigScriptable.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Scriptables/ActionConfigScriptable.cs
@@ -19,7 +19,7 @@ namespace CrashKonijn.Goap.Scriptables
         public int BaseCost { get; set; } = 1;
         
         [field:SerializeField]
-        public float InRange { get; set; } = 0.1f;
+        public float StoppingDistance { get; set; } = 0.1f;
 
         [field: SerializeField]
         public bool RequiresTarget { get; } = true;

--- a/Package/Runtime/CrashKonijn.Goap/Scriptables/CapabilityConfigScriptable.cs
+++ b/Package/Runtime/CrashKonijn.Goap/Scriptables/CapabilityConfigScriptable.cs
@@ -43,7 +43,7 @@ namespace CrashKonijn.Goap.Scriptables
                 ClassType = x.action.GetScript(actionClasses).GetFullName(),
                 BaseCost = x.baseCost,
                 Target = x.target.GetScript(targetClasses).GetInstance<ITargetKey>(),
-                InRange = x.inRange,
+                StoppingDistance = x.inRange,
                 Conditions = x.conditions.Select(y => new Condition
                 {
                     WorldKey = y.worldKey.GetScript(generator.GetWorldKeys()).GetInstance<IWorldKey>(),

--- a/Package/Tests/CrashKonijn.Goap.Tests/UnitTests/ActionRunnerTests.cs
+++ b/Package/Tests/CrashKonijn.Goap.Tests/UnitTests/ActionRunnerTests.cs
@@ -116,7 +116,7 @@ namespace CrashKonijn.Goap.UnitTests
             this.actionRunner.Run();
             
             // Assert
-            this.proxy.Received().SetMoveState(AgentMoveState.OutOfRange);
+            this.proxy.Received().SetMoveState(AgentMoveState.NotInRange);
         }
         
         [Test]
@@ -215,7 +215,7 @@ namespace CrashKonijn.Goap.UnitTests
             this.actionRunner.Run();
             
             // Assert
-            this.proxy.Received().SetMoveState(AgentMoveState.OutOfRange);
+            this.proxy.Received().SetMoveState(AgentMoveState.NotInRange);
         }
         
         [Test]


### PR DESCRIPTION
Fixes #165 

Changes:
- AgentEvents: renamed `OnTargetOutOfRange` to `TargetNotInRange` for clarity.
- ActionConfig: renamed `InRange` to `StoppingDistance` for clarity.
- AgentMoveState: renamed `OutOfRange` to `NotInRange` for clarity.