### PR TITLE
Feature: add TargetLost event

### DIFF
--- a/Package/Runtime/CrashKonijn.Agent.Core/Interfaces/IAgentEvents.cs
+++ b/Package/Runtime/CrashKonijn.Agent.Core/Interfaces/IAgentEvents.cs
@@ -26,7 +26,10 @@ namespace CrashKonijn.Agent.Core
         
         event TargetRangeDelegate OnTargetChanged;
         void TargetChanged(ITarget target, bool inRange);
-
+        
+        event EmptyDelegate OnTargetLost;
+        void TargetLost();
+        
         event TargetDelegate OnMove;
         void Move(ITarget target);
 

--- a/Package/Runtime/CrashKonijn.Agent.Runtime/AgentBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Agent.Runtime/AgentBehaviour.cs
@@ -126,6 +126,9 @@ namespace CrashKonijn.Agent.Runtime
             
             switch (state)
             {
+                case AgentMoveState.Idle:
+                    this.Events.TargetLost();
+                    break;
                 case AgentMoveState.InRange:
                     this.Events.TargetInRange(this.CurrentTarget);
                     break;
@@ -201,7 +204,7 @@ namespace CrashKonijn.Agent.Runtime
         {
             this.ActionState.Reset();
             this.CurrentTarget = null;
-            this.MoveState = AgentMoveState.Idle;
+            SetMoveState(AgentMoveState.Idle);
         }
         
         public void EnableAction<TAction>()

--- a/Package/Runtime/CrashKonijn.Agent.Runtime/AgentBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Agent.Runtime/AgentBehaviour.cs
@@ -99,14 +99,13 @@ namespace CrashKonijn.Agent.Runtime
             
             this.CurrentTarget = this.ActionState.Data?.Target;
             
-            if (this.CurrentTarget != null)
-            {
-                this.Events.TargetChanged(this.CurrentTarget, this.IsInRange());
-            }
-            else
+            if (this.CurrentTarget == null)
             {
                 this.Events.TargetLost();
+                return;
             }
+
+            this.Events.TargetChanged(this.CurrentTarget, this.IsInRange());
         }
 
         private void SetState(AgentState state)

--- a/Package/Runtime/CrashKonijn.Agent.Runtime/AgentBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Agent.Runtime/AgentBehaviour.cs
@@ -85,10 +85,7 @@ namespace CrashKonijn.Agent.Runtime
         public void Run()
         {
             if (this.ActionState.Action == null)
-            {
-                this.SetState(AgentState.NoAction);
                 return;
-            }
             
             this.UpdateTarget();
 
@@ -101,7 +98,15 @@ namespace CrashKonijn.Agent.Runtime
                 return;
             
             this.CurrentTarget = this.ActionState.Data?.Target;
-            this.Events.TargetChanged(this.CurrentTarget, this.IsInRange());
+            
+            if (this.CurrentTarget != null)
+            {
+                this.Events.TargetChanged(this.CurrentTarget, this.IsInRange());
+            }
+            else
+            {
+                this.Events.TargetLost();
+            }
         }
 
         private void SetState(AgentState state)
@@ -126,9 +131,6 @@ namespace CrashKonijn.Agent.Runtime
             
             switch (state)
             {
-                case AgentMoveState.Idle:
-                    this.Events.TargetLost();
-                    break;
                 case AgentMoveState.InRange:
                     this.Events.TargetInRange(this.CurrentTarget);
                     break;
@@ -203,8 +205,9 @@ namespace CrashKonijn.Agent.Runtime
         private void ResetAction()
         {
             this.ActionState.Reset();
-            this.CurrentTarget = null;
-            SetMoveState(AgentMoveState.Idle);
+            this.SetState(AgentState.NoAction);
+            this.SetMoveState(AgentMoveState.Idle);
+            this.UpdateTarget();
         }
         
         public void EnableAction<TAction>()

--- a/Package/Runtime/CrashKonijn.Agent.Runtime/AgentEvents.cs
+++ b/Package/Runtime/CrashKonijn.Agent.Runtime/AgentEvents.cs
@@ -53,6 +53,12 @@ namespace CrashKonijn.Agent.Runtime
             this.OnTargetChanged?.Invoke(target, inRange);
         }
 
+        public event EmptyDelegate OnTargetLost;
+        public void TargetLost()
+        {
+            this.OnTargetLost?.Invoke();
+        }
+
         public event TargetDelegate OnMove;
         public void Move(ITarget target)
         {


### PR DESCRIPTION
There is no way to know whether `AgentBehaviour`'s current target is missing using events. `TargetChanged` is not invoking in this case that's why I added this feature.

My use case: I have AgentMoveBehaviour to follow near enemies which are being detected using sensors. When the enemy goes out of the sensor radius, there is no way to prevent current movement using already implemented events.