### PR TITLE
Feature: provide previous target in sensor

### DIFF
--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Goap/ItemTarget.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Goap/ItemTarget.cs
@@ -6,12 +6,18 @@ namespace CrashKonijn.Goap.Demos.Complex.Goap
 {
     public class ItemTarget : ITarget
     {
-        public IHoldable Item { get; }
+        public IHoldable Item { get; private set; }
         public Vector3 Position => this.Item?.gameObject.transform.position ?? Vector3.zero;
 
         public ItemTarget(IHoldable item)
         {
             this.Item = item;
+        }
+        
+        public ItemTarget SetItem(IHoldable item)
+        {
+            this.Item = item;
+            return this;
         }
     }
 }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/ClosestItemSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/ClosestItemSensor.cs
@@ -21,12 +21,16 @@ namespace CrashKonijn.Goap.Demos.Complex.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             var closest = this.collection.GetFiltered<T>(false, true, agent.Transform.gameObject).Cast<ItemBase>().Closest(agent.Transform.position);
             
             if (closest == null)
                 return null;
+            
+            // Re-use the existing target if the target exists
+            if (target is TransformTarget targetTransform)
+                return targetTransform.SetTransform(closest.transform);
             
             return new TransformTarget(closest.transform);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/ClosestObjectSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/ClosestObjectSensor.cs
@@ -18,12 +18,16 @@ namespace CrashKonijn.Goap.Demos.Complex.Sensors.Target
             this.items = Compatibility.FindObjectsOfType<T>();
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             var closest = this.items.Closest(agent.Transform.position);
             
             if (closest == null)
                 return null;
+            
+            // Re-use the target if it already exists
+            if (target is TransformTarget transformTarget)
+                return transformTarget.SetTransform(closest.transform);
             
             return new TransformTarget(closest.transform);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/ClosestSourceSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/ClosestSourceSensor.cs
@@ -2,7 +2,6 @@
 using CrashKonijn.Goap.Demos.Complex.Behaviours;
 using CrashKonijn.Goap.Demos.Complex.Interfaces;
 using CrashKonijn.Goap.Runtime;
-using UnityEngine;
 
 namespace CrashKonijn.Goap.Demos.Complex.Sensors.Target
 {
@@ -20,12 +19,16 @@ namespace CrashKonijn.Goap.Demos.Complex.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             var closest = this.collection.Closest(agent.Transform.position);
             
             if (closest == null)
                 return null;
+            
+            // Re-use the current target instance
+            if (target is TransformTarget transformTarget)
+                return transformTarget.SetTransform(closest.transform);
             
             return new TransformTarget(closest.transform);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/HaulTargetSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/HaulTargetSensor.cs
@@ -24,12 +24,16 @@ namespace CrashKonijn.Goap.Demos.Complex.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             var item = this.itemCollection.Closest(agent.Transform.position, false, false, agent.Transform.gameObject);
             
             if (item is null)
                 return default;
+            
+            // Re-use the current ItemTarget if it exists
+            if (target is ItemTarget itemTarget)
+                return itemTarget.SetItem(item);
 
             return new ItemTarget(item);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/TransformSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/TransformSensor.cs
@@ -13,8 +13,12 @@ namespace CrashKonijn.Goap.Demos.Complex.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
+            // It's always the same target, return it again if it already exists
+            if (target != null)
+                return target;
+            
             return new TransformTarget(agent.Transform);
         }
     }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/WanderTargetSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Target/WanderTargetSensor.cs
@@ -16,9 +16,13 @@ namespace CrashKonijn.Goap.Demos.Complex.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             var random = this.GetRandomPosition(agent);
+            
+            // If we already have a target, update it with the new position
+            if (target is PositionTarget positionTarget)
+                return positionTarget.SetPosition(random);
             
             return new PositionTarget(random);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Shared/Sensors/Target/TransformSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Shared/Sensors/Target/TransformSensor.cs
@@ -14,7 +14,7 @@ namespace Demos.Shared.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             return new TransformTarget(agent.Transform);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Shared/Sensors/Target/WanderTargetSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Shared/Sensors/Target/WanderTargetSensor.cs
@@ -1,5 +1,4 @@
 ﻿using CrashKonijn.Agent.Core;
-using CrashKonijn.Goap;
 using CrashKonijn.Goap.Runtime;
 using UnityEngine;
 
@@ -17,9 +16,14 @@ namespace Demos.Simple.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             var random = this.GetRandomPosition(agent);
+            
+            if (target is PositionTarget positionTarget)
+            {
+                return positionTarget.SetPosition(random);
+            }
             
             return new PositionTarget(random);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Goap/Sensors/Multi/AppleSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Goap/Sensors/Multi/AppleSensor.cs
@@ -25,19 +25,32 @@ namespace CrashKonijn.Goap.Demos.Simple.Goap.Sensors.Multi
 
         public AppleSensor()
         {
-            this.AddLocalTargetSensor<ClosestApple>((agent, references) =>
+            this.AddLocalTargetSensor<ClosestApple>((agent, references, target) =>
             {
                 var closestApple = this.apples.Get().Closest(agent.Transform.position);
 
                 if (closestApple is null)
                     return null;
+                
+                // Re-use the target if it already exists
+                if (target is TransformTarget transformTarget)
+                    return transformTarget.SetTransform(closestApple.transform);
             
                 return new TransformTarget(closestApple.transform);
             });
             
-            this.AddLocalTargetSensor<ClosestTree>((agent, references) =>
+            this.AddLocalTargetSensor<ClosestTree>((agent, references, target) =>
             {
-                return new TransformTarget(this.trees.Closest(agent.Transform.position).transform);
+                var closetTree = this.trees.Closest(agent.Transform.position);
+                
+                if (closetTree is null)
+                    return null;
+                
+                // Re-use the target if it already exists
+                if (target is TransformTarget transformTarget)
+                    return transformTarget.SetTransform(closetTree.transform);
+                
+                return new TransformTarget(closetTree.transform);
             });
             
             this.AddLocalWorldSensor<HasApple>((agent, references) =>

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Goap/Sensors/Target/AgentSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Goap/Sensors/Target/AgentSensor.cs
@@ -14,7 +14,7 @@ namespace CrashKonijn.Goap.Demos.Simple.Goap.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             return new TransformTarget(agent.Transform);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Goap/Sensors/Target/ClosestTreeSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Goap/Sensors/Target/ClosestTreeSensor.cs
@@ -2,7 +2,6 @@
 using CrashKonijn.Goap.Demos.Simple.Behaviours;
 using CrashKonijn.Goap.Runtime;
 using Demos;
-using UnityEngine;
 
 namespace CrashKonijn.Goap.Demos.Simple.Goap.Sensors.Target
 {
@@ -20,7 +19,7 @@ namespace CrashKonijn.Goap.Demos.Simple.Goap.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             return new TransformTarget(this.trees.Closest(agent.Transform.position).transform);
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Goap/Sensors/Target/WanderTargetSensor.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Simple/Goap/Sensors/Target/WanderTargetSensor.cs
@@ -17,7 +17,7 @@ namespace CrashKonijn.Goap.Demos.Simple.Goap.Sensors.Target
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             var random = this.GetRandomPosition(agent);
             

--- a/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IMultiSensor.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IMultiSensor.cs
@@ -6,8 +6,6 @@ namespace CrashKonijn.Goap.Core
     public interface IMultiSensor : IHasConfig<IMultiSensorConfig>, ILocalSensor, IGlobalSensor
     {
         string[] GetSensors();
-        void Sense(IWorldData data, Type[] keys);
-        void Sense(IWorldData data, IActionReceiver agent, IComponentReference references, Type[] keys);
     }
 
     public interface ISensor

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/PositionTarget.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/PositionTarget.cs
@@ -5,11 +5,17 @@ namespace CrashKonijn.Goap.Runtime
 {
     public class PositionTarget : ITarget
     {
-        public Vector3 Position { get; }
+        public Vector3 Position { get; private set; }
 
         public PositionTarget(Vector3 position)
         {
             this.Position = position;
+        }
+        
+        public PositionTarget SetPosition(Vector3 position)
+        {
+            this.Position = position;
+            return this;
         }
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/TransformTarget.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/TransformTarget.cs
@@ -5,7 +5,7 @@ namespace CrashKonijn.Goap.Runtime
 {
     public class TransformTarget : ITarget
     {
-        public Transform Transform { get; }
+        public Transform Transform { get; private set; }
 
         public Vector3 Position
         {
@@ -21,6 +21,12 @@ namespace CrashKonijn.Goap.Runtime
         public TransformTarget(Transform transform)
         {
             this.Transform = transform;
+        }
+
+        public TransformTarget SetTransform(Transform transform)
+        {
+            this.Transform = transform;
+            return this;
         }
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Sensors/GlobalTargetSensorBase.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Sensors/GlobalTargetSensorBase.cs
@@ -16,9 +16,9 @@ namespace CrashKonijn.Goap.Runtime
 
         public void Sense(IWorldData worldData)
         {
-            worldData.SetTarget(this.Key, this.Sense());
+            worldData.SetTarget(this.Key, this.Sense(worldData.GetTargetValue(this.Key.GetType())));
         }
-        
-        public abstract ITarget Sense();
+
+        public abstract ITarget Sense(ITarget target);
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Sensors/LocalTargetSensorBase.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Sensors/LocalTargetSensorBase.cs
@@ -16,17 +16,18 @@ namespace CrashKonijn.Goap.Runtime
 
         public void Sense(IWorldData worldData, IActionReceiver agent, IComponentReference references)
         {
-            worldData.SetTarget(this.Key, this.Sense(agent, references));
+            worldData.SetTarget(this.Key, this.Sense(agent, references, worldData.GetTargetValue(this.Key.GetType())));
         }
 
+        public abstract ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget existingTarget);
+        
+        [Obsolete("This should not be used anymore! Use 'Sense(IActionReceiver agent, IComponentReference references, ITarget existingTarget) instead'")]
         public virtual ITarget Sense(IActionReceiver agent, IComponentReference references)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            return this.Sense(agent as IMonoAgent, references);
-#pragma warning restore CS0618 // Type or member is obsolete
+            throw new GoapException("This should not be called anymore!");
         }
 
-        [Obsolete("This should not be called anymore! Use 'Sense(IActionReceiver agent, IComponentReference references)'")]
+        [Obsolete("This should not be used anymore! Use 'Sense(IActionReceiver agent, IComponentReference references)'")]
         public virtual ITarget Sense(IMonoAgent agent, IComponentReference references)
         {
             throw new GoapException("This should not be called anymore!");

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Sensors/MultiSensorBase.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Sensors/MultiSensorBase.cs
@@ -102,7 +102,7 @@ namespace CrashKonijn.Goap.Runtime
             });
         }
 
-        public void AddLocalTargetSensor<TKey>(Func<IActionReceiver, IComponentReference, ITarget> sense)
+        public void AddLocalTargetSensor<TKey>(Func<IActionReceiver, IComponentReference, ITarget, ITarget> sense)
             where TKey : ITargetKey
         {
             this.LocalSensors.Add(typeof(TKey), new LocalSensor
@@ -110,12 +110,12 @@ namespace CrashKonijn.Goap.Runtime
                 Key = typeof(TKey),
                 Sense = (IWorldData data, IActionReceiver agent, IComponentReference references) =>
                 {
-                    data.SetTarget<TKey>(sense(agent, references));
+                    data.SetTarget<TKey>(sense(agent, references, data.GetTargetValue(typeof(TKey))));
                 }
             });
         }
 
-        public void AddGlobalTargetSensor<TKey>(Func<ITarget> sense)
+        public void AddGlobalTargetSensor<TKey>(Func<ITarget, ITarget> sense)
             where TKey : ITargetKey
         {
             this.GlobalSensors.Add(typeof(TKey), new GlobalSensor
@@ -123,7 +123,7 @@ namespace CrashKonijn.Goap.Runtime
                 Key = typeof(TKey),
                 Sense = (IWorldData data) =>
                 {
-                    data.SetTarget<TKey>(sense());
+                    data.SetTarget<TKey>(sense(data.GetTargetValue(typeof(TKey))));
                 }
             });
         }

--- a/Package/Tests/CrashKonijn.Goap.Tests/UnitTests/Data/LocalTargetSensor.cs
+++ b/Package/Tests/CrashKonijn.Goap.Tests/UnitTests/Data/LocalTargetSensor.cs
@@ -13,7 +13,7 @@ namespace CrashKonijn.Goap.UnitTests.Data
         {
         }
 
-        public override ITarget Sense(IActionReceiver agent, IComponentReference references)
+        public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
         {
             return default;
         }

--- a/Package/Tests/CrashKonijn.Goap.Tests/UnitTests/MultiSensorBaseTests.cs
+++ b/Package/Tests/CrashKonijn.Goap.Tests/UnitTests/MultiSensorBaseTests.cs
@@ -46,8 +46,8 @@ namespace CrashKonijn.Goap.UnitTests
         public void AddLocalAndGlobalTargetSensor_AddsSensorsCorrectly()
         {
             // Act
-            this.multiSensorBase.AddLocalTargetSensor<ITargetKey>((_, _) => null);
-            this.multiSensorBase.AddGlobalTargetSensor<ITargetKey>(() => null);
+            this.multiSensorBase.AddLocalTargetSensor<ITargetKey>((_, _, _) => null);
+            this.multiSensorBase.AddGlobalTargetSensor<ITargetKey>((_) => null);
 
             // Assert
             Assert.AreEqual(1, this.multiSensorBase.LocalSensors.Count);
@@ -97,7 +97,7 @@ namespace CrashKonijn.Goap.UnitTests
             var targetValue = Substitute.For<ITarget>();
 
             this.multiSensorBase.AddLocalWorldSensor<IWorldKey>((_, _) => worldValue);
-            this.multiSensorBase.AddLocalTargetSensor<ITargetKey>((_, _) => targetValue);
+            this.multiSensorBase.AddLocalTargetSensor<ITargetKey>((_, _, _) => targetValue);
 
             // Act
             this.multiSensorBase.Sense(this.mockWorldData, this.mockMonoAgent, this.mockComponentReference);
@@ -115,7 +115,7 @@ namespace CrashKonijn.Goap.UnitTests
             var targetValue = Substitute.For<ITarget>();
 
             this.multiSensorBase.AddGlobalWorldSensor<IWorldKey>(() => worldValue);
-            this.multiSensorBase.AddGlobalTargetSensor<ITargetKey>(() => targetValue);
+            this.multiSensorBase.AddGlobalTargetSensor<ITargetKey>((_) => targetValue);
 
             // Act
             this.multiSensorBase.Sense(this.mockWorldData);


### PR DESCRIPTION
Provides the previous target in target sensors. The existing ITarget implementations have been updated so their value can be updated.

```csharp
public override ITarget Sense(IActionReceiver agent, IComponentReference references, ITarget target)
{
    // It's always the same target, return it again if it already exists
    if (target != null)
        return target;

    return new TransformTarget(agent.Transform);
}
```