### PR TITLE
Fix: multi sensor missing keys warning

### DIFF
--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/Capabilities/HungerCapability.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/Capabilities/HungerCapability.cs
@@ -4,10 +4,12 @@ using CrashKonijn.Goap.Demos.Complex.Classes.Items;
 using CrashKonijn.Goap.Demos.Complex.Factories.Extensions;
 using CrashKonijn.Goap.Demos.Complex.Goals;
 using CrashKonijn.Goap.Demos.Complex.Interfaces;
+using CrashKonijn.Goap.Demos.Complex.Sensors.Multi;
 using CrashKonijn.Goap.Demos.Complex.Sensors.World;
 using CrashKonijn.Goap.Demos.Complex.Targets;
 using CrashKonijn.Goap.Demos.Complex.WorldKeys;
 using CrashKonijn.Goap.Runtime;
+using TransformTarget = CrashKonijn.Goap.Demos.Complex.Targets.TransformTarget;
 
 namespace CrashKonijn.Goap.Demos.Complex.Factories.Capabilities
 {
@@ -20,15 +22,15 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories.Capabilities
             // Goals
             builder.AddGoal<FixHungerGoal>()
                 .AddCondition<Hunger>(Comparison.SmallerThanOrEqual, 0);
-            
+
             // Actions
             builder.AddAction<EatAction>()
-                .SetTarget<Targets.TransformTarget>()
+                .SetTarget<TransformTarget>()
                 .AddEffect<Hunger>(EffectType.Decrease)
                 .AddCondition<IsHolding<IEatable>>(Comparison.GreaterThanOrEqual, 1)
                 .AddCondition<Hunger>(Comparison.GreaterThanOrEqual, 30)
                 .SetValidateConditions(false); // We don't need to validate conditions for this action, or it will stop when becoming below 80 hunger
-            
+
             builder.AddAction<GatherItemAction<Apple>>()
                 .SetTarget<ClosestSourceTarget<Apple>>()
                 .AddEffect<IsHolding<IEatable>>(EffectType.Increase)
@@ -36,20 +38,21 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories.Capabilities
                 .SetProperties(new GatherItemAction<Apple>.Props
                 {
                     pickupItem = true,
-                    timer = 3
+                    timer = 3,
                 });
-            
+
             builder.AddPickupItemAction<IEatable>();
-            
+
             // Target sensors
-            builder.AddClosestItemTargetSensor<IEatable>();
             builder.AddClosestSourceTargetSensor<Apple>();
-            
+
             // World sensors
             builder.AddIsHoldingSensor<IEatable>();
-            builder.AddIsInWorldSensor<IEatable>();
             builder.AddWorldSensor<HungerSensor>()
                 .SetKey<Hunger>();
+
+            // Multi sensor
+            builder.AddMultiSensor<ItemSensor<IEatable>>();
 
             return builder.Build();
         }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/Extensions/TargetSensorExtensions.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/Extensions/TargetSensorExtensions.cs
@@ -8,13 +8,6 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories.Extensions
 {
     public static class TargetSensorExtensions
     {
-        public static void AddClosestItemTargetSensor<T>(this CapabilityBuilder builder)
-            where T : class, IHoldable
-        {
-            builder.AddTargetSensor<ClosestItemSensor<T>>()
-                .SetTarget<ClosestTarget<T>>();
-        }
-        
         public static void AddClosestObjectTargetSensor<T>(this CapabilityBuilder builder)
             where T : MonoBehaviour
         {

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/Extensions/WorldSensorExtensions.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/Extensions/WorldSensorExtensions.cs
@@ -13,12 +13,5 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories.Extensions
             builder.AddWorldSensor<IsHoldingSensor<THoldable>>()
                 .SetKey<IsHolding<THoldable>>();
         }
-        
-        public static void AddIsInWorldSensor<THoldable>(this CapabilityBuilder builder)
-            where THoldable : IHoldable
-        {
-            builder.AddWorldSensor<IsInWorldSensor<THoldable>>()
-                .SetKey<IsInWorld<THoldable>>();
-        }
     }
 }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/MinerAgentTypeConfigFactory.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/MinerAgentTypeConfigFactory.cs
@@ -3,6 +3,7 @@ using CrashKonijn.Goap.Demos.Complex.Classes;
 using CrashKonijn.Goap.Demos.Complex.Classes.Items;
 using CrashKonijn.Goap.Demos.Complex.Factories.Capabilities;
 using CrashKonijn.Goap.Demos.Complex.Factories.Extensions;
+using CrashKonijn.Goap.Demos.Complex.Sensors.Multi;
 using CrashKonijn.Goap.Runtime;
 
 namespace CrashKonijn.Goap.Demos.Complex.Factories
@@ -12,33 +13,31 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories
         public override IAgentTypeConfig Create()
         {
             var builder = new AgentTypeBuilder(SetIds.Miner);
-            
+
             builder.AddCapability<BaseCapability>();
             builder.AddCapability<WanderCapability>();
             builder.AddCapability<HungerCapability>();
-            
+
             builder.CreateCapability("MineCapability", (capability) =>
             {
                 capability.AddPickupItemGoal<Pickaxe>();
                 capability.AddGatherItemGoal<Iron>();
-                
+
                 capability.AddPickupItemAction<Pickaxe>();
-                
+
                 capability.AddGatherItemAction<Iron, Pickaxe>();
                 capability.AddGatherItemSlowAction<Iron>();
-                
-                capability.AddClosestItemTargetSensor<Iron>();
-                capability.AddClosestItemTargetSensor<Pickaxe>();
-                
+
                 capability.AddClosestSourceTargetSensor<Iron>();
-                
+
                 capability.AddIsHoldingSensor<Pickaxe>();
                 capability.AddIsHoldingSensor<Iron>();
-                
-                capability.AddIsInWorldSensor<Pickaxe>();
-                capability.AddIsInWorldSensor<Iron>();
+
+                // Multi sensor
+                capability.AddMultiSensor<ItemSensor<Pickaxe>>();
+                capability.AddMultiSensor<ItemSensor<Iron>>();
             });
-            
+
             return builder.Build();
         }
     }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/SmithAgentTypeConfigFactory.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/SmithAgentTypeConfigFactory.cs
@@ -4,6 +4,7 @@ using CrashKonijn.Goap.Demos.Complex.Classes.Items;
 using CrashKonijn.Goap.Demos.Complex.Classes.Sources;
 using CrashKonijn.Goap.Demos.Complex.Factories.Capabilities;
 using CrashKonijn.Goap.Demos.Complex.Factories.Extensions;
+using CrashKonijn.Goap.Demos.Complex.Sensors.Multi;
 using CrashKonijn.Goap.Runtime;
 
 namespace CrashKonijn.Goap.Demos.Complex.Factories
@@ -13,7 +14,7 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories
         public override IAgentTypeConfig Create()
         {
             var builder = new AgentTypeBuilder(SetIds.Smith);
-            
+
             builder.AddCapability<BaseCapability>();
             builder.AddCapability<WanderCapability>();
             builder.AddCapability<HungerCapability>();
@@ -34,9 +35,6 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories
                 // TargetSensors
                 capability.AddClosestObjectTargetSensor<AnvilSource>();
 
-                capability.AddClosestItemTargetSensor<Iron>();
-                capability.AddClosestItemTargetSensor<Wood>();
-
                 capability.AddClosestSourceTargetSensor<Iron>();
                 capability.AddClosestSourceTargetSensor<Wood>();
 
@@ -44,10 +42,11 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories
                 capability.AddIsHoldingSensor<Wood>();
                 capability.AddIsHoldingSensor<Iron>();
 
-                capability.AddIsInWorldSensor<Axe>();
-                capability.AddIsInWorldSensor<Pickaxe>();
-                capability.AddIsInWorldSensor<Wood>();
-                capability.AddIsInWorldSensor<Iron>();
+                // Multi sensor
+                capability.AddMultiSensor<ItemSensor<Axe>>();
+                capability.AddMultiSensor<ItemSensor<Pickaxe>>();
+                capability.AddMultiSensor<ItemSensor<Wood>>();
+                capability.AddMultiSensor<ItemSensor<Iron>>();
             });
 
             return builder.Build();

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/WoodCutterAgentTypeConfigFactory.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Factories/WoodCutterAgentTypeConfigFactory.cs
@@ -3,6 +3,7 @@ using CrashKonijn.Goap.Demos.Complex.Classes;
 using CrashKonijn.Goap.Demos.Complex.Classes.Items;
 using CrashKonijn.Goap.Demos.Complex.Factories.Capabilities;
 using CrashKonijn.Goap.Demos.Complex.Factories.Extensions;
+using CrashKonijn.Goap.Demos.Complex.Sensors.Multi;
 using CrashKonijn.Goap.Runtime;
 
 namespace CrashKonijn.Goap.Demos.Complex.Factories
@@ -12,37 +13,35 @@ namespace CrashKonijn.Goap.Demos.Complex.Factories
         public override IAgentTypeConfig Create()
         {
             var builder = new AgentTypeBuilder(SetIds.WoodCutter);
-            
+
             builder.AddCapability<BaseCapability>();
             builder.AddCapability<WanderCapability>();
             builder.AddCapability<HungerCapability>();
-            
+
             builder.CreateCapability("WoodCutterCapability", (capability) =>
             {
                 // Goals
                 capability.AddPickupItemGoal<Axe>();
                 capability.AddGatherItemGoal<Wood>();
-                
+
                 // Actions
                 capability.AddPickupItemAction<Axe>();
-                
+
                 capability.AddGatherItemAction<Wood, Axe>();
                 capability.AddGatherItemSlowAction<Wood>();
-                
+
                 // Target sensors
-                capability.AddClosestItemTargetSensor<Axe>();
-                capability.AddClosestItemTargetSensor<Wood>();
-                
                 capability.AddClosestSourceTargetSensor<Wood>();
-                
+
                 // World sensors
                 capability.AddIsHoldingSensor<Axe>();
                 capability.AddIsHoldingSensor<Wood>();
-                
-                capability.AddIsInWorldSensor<Axe>();
-                capability.AddIsInWorldSensor<Wood>();
+
+                // Multi sensor
+                capability.AddMultiSensor<ItemSensor<Axe>>();
+                capability.AddMultiSensor<ItemSensor<Wood>>();
             });
-            
+
             return builder.Build();
         }
     }

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Multi.meta
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Multi.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d360d904c1834f9c9bf72cf2c2b5e469
+timeCreated: 1730975891

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Multi/ItemSensors.cs
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Multi/ItemSensors.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using CrashKonijn.Agent.Core;
+using CrashKonijn.Goap.Core;
+using CrashKonijn.Goap.Demos.Complex.Behaviours;
+using CrashKonijn.Goap.Demos.Complex.Interfaces;
+using CrashKonijn.Goap.Demos.Complex.Targets;
+using CrashKonijn.Goap.Demos.Complex.WorldKeys;
+using CrashKonijn.Goap.Runtime;
+using UnityEngine;
+using TransformTarget = CrashKonijn.Goap.Runtime.TransformTarget;
+
+namespace CrashKonijn.Goap.Demos.Complex.Sensors.Multi
+{
+    public class ItemSensor<T> : MultiSensorBase
+        where T : class, IHoldable
+    {
+        private ItemCollection collection;
+
+        public ItemSensor()
+        {
+            this.AddLocalTargetSensor<ClosestTarget<T>>(this.SenseClosestTarget);
+            this.AddLocalWorldSensor<IsInWorld<T>>(this.SenseIsInWorld);
+        }
+
+        public override void Created()
+        {
+            this.collection = Object.FindObjectOfType<ItemCollection>();
+        }
+
+        public override void Update() { }
+
+        private ITarget SenseClosestTarget(IActionReceiver agent, IComponentReference references, ITarget target)
+        {
+            var closest = this.collection.GetFiltered<T>(false, true, agent.Transform.gameObject).Cast<ItemBase>().Closest(agent.Transform.position);
+
+            if (closest == null)
+                return null;
+
+            // Re-use the existing target if the target exists
+            if (target is TransformTarget targetTransform)
+                return targetTransform.SetTransform(closest.transform);
+
+            return new TransformTarget(closest.transform);
+        }
+
+        private SenseValue SenseIsInWorld(IActionReceiver agent, IComponentReference references)
+        {
+            return this.collection.GetFiltered<T>(false, true, agent.Transform.gameObject).Length;
+        }
+    }
+}

--- a/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Multi/ItemSensors.cs.meta
+++ b/Demo/Assets/CrashKonijn/GOAP/Demos/Complex/Sensors/Multi/ItemSensors.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6a4a0a2524ae44609cd761aeab66947f
+timeCreated: 1730975891

--- a/Demo/Assets/Docs/GettingStarted/Sensors/PearSensor.cs
+++ b/Demo/Assets/Docs/GettingStarted/Sensors/PearSensor.cs
@@ -1,8 +1,8 @@
-using System;
 using System.Collections.Generic;
 using CrashKonijn.Docs.GettingStarted.Behaviours;
 using CrashKonijn.Goap.Runtime;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace CrashKonijn.Docs.GettingStarted.Sensors
 {
@@ -11,9 +11,9 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
         // A cache of all the pears in the world
         private PearBehaviour[] pears;
 
-        // The Created method is called when the sensor is created
-        // You must use this method to register all the sensors
-        public override void Created()
+        // You must use the constructor to register all the sensors
+        // This can also be called outside of the gameplay loop to validate the configuration
+        public PearSensor()
         {
             this.AddLocalWorldSensor<PearCount>((agent, references) =>
             {
@@ -22,7 +22,7 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
 
                 return data.pearCount;
             });
-            
+
             this.AddLocalWorldSensor<Hunger>((agent, references) =>
             {
                 // Get a cached reference to the DataBehaviour on the agent
@@ -32,28 +32,32 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
                 // We will lose the decimal values, but we don't need them for this example
                 return (int) data.hunger;
             });
-            
+
             this.AddLocalTargetSensor<ClosestPear>((agent, references, target) =>
             {
                 // Use the cashed pears list to find the closest pear
                 var closestPear = this.Closest(this.pears, agent.Transform.position);
-                
+
                 if (closestPear == null)
                     return null;
-                
+
                 // If the target is a transform target, set the target to the closest pear
                 if (target is TransformTarget transformTarget)
                     return transformTarget.SetTransform(closestPear.transform);
-                
+
                 return new TransformTarget(closestPear.transform);
             });
         }
-        
+
+        // The Created method is called when the sensor is created
+        // This can be used to gather references to objects in the scene
+        public override void Created() { }
+
         // This method is equal to the Update method of a local sensor.
         // It can be used to cache data, like gathering a list of all pears in the scene.
         public override void Update()
         {
-            this.pears = GameObject.FindObjectsOfType<PearBehaviour>();
+            this.pears = Object.FindObjectsOfType<PearBehaviour>();
         }
 
         // Returns the closest item in a list
@@ -66,10 +70,10 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
             foreach (var item in list)
             {
                 var distance = Vector3.Distance(item.gameObject.transform.position, position);
-                
+
                 if (!(distance < closestDistance))
                     continue;
-                
+
                 closest = item;
                 closestDistance = distance;
             }

--- a/Package/Documentation/Classes/Sensors.md
+++ b/Package/Documentation/Classes/Sensors.md
@@ -172,9 +172,9 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
         // A cache of all the pears in the world
         private PearBehaviour[] pears;
 
-        // The Created method is called when the sensor is created
-        // You must use this method to register all the sensors
-        public override void Created()
+        // You must use the constructor to register all the sensors
+        // This can also be called outside of the gameplay loop to validate the configuration
+        public PearSensor()
         {
             this.AddLocalWorldSensor<PearCount>((agent, references) =>
             {
@@ -208,6 +208,12 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
                 
                 return new TransformTarget(closestPear.transform);
             });
+        }
+
+        // The Created method is called when the sensor is created
+        // This can be used to gather references to objects in the scene
+        public override void Created()
+        {
         }
         
         // This method is equal to the Update method of a local sensor.
@@ -290,7 +296,7 @@ public class AgentSensor : LocalTargetSensorBase
 ```csharp
 public class PearSensor : MultiSensorBase
 {
-    public override void Created()
+    public PearSensor()
     {
         // You can set the timer for each sensor individually in the second parameter
         this.AddLocalWorldSensor<PearCount>((agent, references) =>

--- a/Package/Documentation/Introduction/Pears.md
+++ b/Package/Documentation/Introduction/Pears.md
@@ -73,9 +73,9 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
         // A cache of all the pears in the world
         private PearBehaviour[] pears;
 
-        // The Created method is called when the sensor is created
-        // You must use this method to register all the sensors
-        public override void Created()
+        // You must use the constructor to register all the sensors
+        // This can also be called outside of the gameplay loop to validate the configuration
+        public PearSensor()
         {
             this.AddLocalWorldSensor<PearCount>((agent, references) =>
             {
@@ -110,6 +110,12 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
                 return new TransformTarget(closestPear.transform);
             });
         }
+
+        // The Created method is called when the sensor is created
+        // This can be used to gather references to objects in the scene
+        public override void Created()
+        {
+        }
         
         // This method is equal to the Update method of a local sensor.
         // It can be used to cache data, like gathering a list of all pears in the scene.
@@ -140,7 +146,6 @@ namespace CrashKonijn.Docs.GettingStarted.Sensors
         }
     }
 }
-
 ```
 {% endcode %}
 

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/DuplicateTargetSensorValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/DuplicateTargetSensorValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using CrashKonijn.Agent.Runtime;
 using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
@@ -34,7 +35,7 @@ namespace CrashKonijn.Goap.Runtime
 
             return temp
                 .SelectMany(x => x.GetKeys())
-                .Select(x => x.Name)
+                .Select(x => x.GetGenericTypeName())
                 .ToArray();
         }
     }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/DuplicateWorldSensorValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/DuplicateWorldSensorValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using CrashKonijn.Agent.Runtime;
 using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
@@ -35,7 +36,7 @@ namespace CrashKonijn.Goap.Runtime
 
             return temp
                 .SelectMany(x => x.GetKeys())
-                .Select(x => x.Name)
+                .Select(x => x.GetGenericTypeName())
                 .Distinct()
                 .ToArray();
         }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/TargetKeySensorsValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/TargetKeySensorsValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using CrashKonijn.Agent.Runtime;
 using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
@@ -33,7 +34,7 @@ namespace CrashKonijn.Goap.Runtime
 
             return temp
                 .SelectMany(x => x.GetKeys())
-                .Select(x => x.Name)
+                .Select(x => x.GetGenericTypeName())
                 .Distinct()
                 .ToArray();
         }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/WorldKeySensorsValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/WorldKeySensorsValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using CrashKonijn.Agent.Runtime;
 using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
@@ -29,11 +30,11 @@ namespace CrashKonijn.Goap.Runtime
 
         private string[] GetMultiSensorKeys(IAgentTypeConfig agentTypeConfig)
         {
-            var temp = new ClassResolver().Load<IMultiSensor, IMultiSensorConfig>(agentTypeConfig.MultiSensors);
+            var sensors = new ClassResolver().Load<IMultiSensor, IMultiSensorConfig>(agentTypeConfig.MultiSensors);
 
-            return temp
+            return sensors
                 .SelectMany(x => x.GetKeys())
-                .Select(x => x.Name)
+                .Select(x => x.GetGenericTypeName())
                 .Distinct()
                 .ToArray();
         }


### PR DESCRIPTION
Multisensors that didn't register their sensors in the constructor are not correctly processed by the config validator. These will now throw an error when they are registered outside of the constructor.