### PR TITLE
Feature: removed name prop from keys

### DIFF
--- a/Package/Editor/CrashKonijn.Goap.Editor/GraphViewer/ConditionElement.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/GraphViewer/ConditionElement.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using CrashKonijn.Goap.Core;
+using CrashKonijn.Goap.Runtime;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -22,7 +23,7 @@ namespace CrashKonijn.Goap.Editor
 
             this.Circle = new Circle(this.GetCircleColor(graphCondition), 10f);
             this.Add(this.Circle);
-            
+
             this.Label = new Label(this.GetText(graphCondition.Condition));
             this.Add(this.Label);
 
@@ -37,10 +38,10 @@ namespace CrashKonijn.Goap.Editor
         {
             if (Application.isPlaying)
                 return this.GetLiveColor();
-            
+
             if (!condition.Connections.Any())
                 return Color.red;
-            
+
             return Color.green;
         }
 
@@ -48,36 +49,36 @@ namespace CrashKonijn.Goap.Editor
         {
             if (this.values.SelectedObject is not IMonoGoapActionProvider agent)
                 return Color.white;
-            
+
             if (agent.AgentType == null)
                 return Color.white;
-                
+
             var conditionObserver = agent.AgentType.GoapConfig.ConditionObserver;
             conditionObserver.SetWorldData(agent.WorldData);
-            
+
             return conditionObserver.IsMet(this.GraphCondition.Condition) ? Color.green : Color.red;
         }
-        
+
         private string GetText(ICondition condition)
         {
             var suffix = this.GetSuffix(condition);
-            
-            return $"{condition.WorldKey.Name} {this.GetText(condition.Comparison)} {condition.Amount} {suffix}";
+
+            return $"{condition.WorldKey.GetName()} {this.GetText(condition.Comparison)} {condition.Amount} {suffix}";
         }
 
         private string GetSuffix(ICondition condition)
         {
             if (!Application.isPlaying)
                 return "";
-            
+
             if (this.values.SelectedObject is not IMonoGoapActionProvider agent)
                 return "";
-            
+
             var (exists, value) = agent.WorldData.GetWorldValue(condition.WorldKey);
-            
+
             return "(" + (exists ? value.ToString() : "-") + ")";
         }
-        
+
         private string GetText(Comparison comparison)
         {
             switch (comparison)
@@ -91,7 +92,7 @@ namespace CrashKonijn.Goap.Editor
                 case Comparison.SmallerThanOrEqual:
                     return "<=";
             }
-            
+
             return "";
         }
     }

--- a/Package/Editor/CrashKonijn.Goap.Editor/GraphViewer/EffectElement.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/GraphViewer/EffectElement.cs
@@ -1,4 +1,5 @@
 ﻿using CrashKonijn.Goap.Core;
+using CrashKonijn.Goap.Runtime;
 using UnityEngine.UIElements;
 
 namespace CrashKonijn.Goap.Editor
@@ -11,16 +12,16 @@ namespace CrashKonijn.Goap.Editor
         {
             this.GraphEffect = graphEffect;
             this.AddToClassList("effect");
-            
+
             this.Label = new Label(this.GetText(graphEffect.Effect));
             this.Add(this.Label);
         }
-        
+
         private string GetText(IEffect effect)
         {
             var suffix = effect.Increase ? "++" : "--";
 
-            return $"{effect.WorldKey.Name}{suffix}";
+            return $"{effect.WorldKey.GetName()}{suffix}";
         }
 
         public Label Label { get; set; }

--- a/Package/Editor/CrashKonijn.Goap.Editor/Styles/GraphViewer.uss
+++ b/Package/Editor/CrashKonijn.Goap.Editor/Styles/GraphViewer.uss
@@ -184,8 +184,8 @@
 }
 
 .node-wrapper, .child-wrapper {
-    flex-grow: 0; /* Don’t grow larger than content */
-    flex-shrink: 0; /* Don’t shrink smaller than content */
+    /*flex-grow: 0; !* Don’t grow larger than content *!*/
+    /*flex-shrink: 0; !* Don’t shrink smaller than content *!*/
 
     margin: 10px 20px;
 

--- a/Package/Editor/CrashKonijn.Goap.Editor/TypeDrawers/GoapSetConfigEditor.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/TypeDrawers/GoapSetConfigEditor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using CrashKonijn.Goap.Core;
 using CrashKonijn.Goap.Runtime;
@@ -15,16 +14,16 @@ namespace CrashKonijn.Goap.Editor
     public class GoapSetConfigEditor : UnityEditor.Editor
     {
         private GoapSetConfigScriptable config;
-        
+
         public override VisualElement CreateInspectorGUI()
         {
             this.config = (GoapSetConfigScriptable) this.target;
-            
+
             var root = new VisualElement();
-            
+
             var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>($"{GoapEditorSettings.BasePath}/Styles/Generic.uss");
             root.styleSheets.Add(styleSheet);
-            
+
             root.Add(this.Group("Upgrade", card =>
             {
                 // CapabilityConfigScriptable capabilityScriptable = default;
@@ -42,15 +41,15 @@ namespace CrashKonijn.Goap.Editor
                 // });
                 //
                 // card.Add(input);
-                
+
                 card.Add(new PropertyField(this.serializedObject.FindProperty("capabilityConfig")));
-                
+
                 var button = new Button(() =>
                 {
                     this.Upgrade(this.config.capabilityConfig);
                 })
                 {
-                    text = "Upgrade to CapabilityConfigs"
+                    text = "Upgrade to CapabilityConfigs",
                 };
 
                 card.Add(button);
@@ -61,44 +60,44 @@ namespace CrashKonijn.Goap.Editor
                 card.Add(new PropertyField(this.serializedObject.FindProperty("actions")));
                 card.Add(new PropertyField(this.serializedObject.FindProperty("goals")));
             }));
-            
+
             root.Add(this.Group("World Keys", card =>
             {
                 card.Add(new PropertyField(this.serializedObject.FindProperty("worldSensors")));
                 card.Add(this.SimpleLabelView("World keys", this.config.GetWorldKeys(), (label, key) =>
                 {
-                    label.text = key.Name;
+                    label.text = key.GetName();
                 }));
             }));
-            
+
             root.Add(this.Group("Targets", card =>
             {
                 card.Add(new PropertyField(this.serializedObject.FindProperty("targetSensors")));
                 card.Add(this.SimpleLabelView("Target keys", this.config.GetTargetKeys(), (label, key) =>
                 {
-                    label.text = key.Name;
+                    label.text = key.GetName();
                 }));
             }));
-            
+
             var validateButton = new Button(() =>
             {
                 var validator = new AgentTypeConfigValidatorRunner();
                 var results = validator.Validate(this.config);
-                
+
                 foreach (var error in results.GetErrors())
                 {
                     Debug.LogError(error);
                 }
-            
+
                 foreach (var warning in results.GetWarnings())
                 {
                     Debug.LogWarning(warning);
                 }
-                
+
                 if (!results.HasErrors() && !results.HasWarnings())
                     Debug.Log("No errors or warnings found!");
             });
-            
+
             validateButton.Add(new Label("Validate"));
 
             root.Add(validateButton);
@@ -115,21 +114,21 @@ namespace CrashKonijn.Goap.Editor
                 {
                     goal = new ClassRef
                     {
-                        Name = this.GetName(goalConfig.ClassType)
+                        Name = this.GetName(goalConfig.ClassType),
                     },
                     baseCost = goalConfig.BaseCost,
                     conditions = goalConfig.Conditions.Select(x => new CapabilityCondition
                     {
                         worldKey = new ClassRef
                         {
-                            Name = x.WorldKey.Name
+                            Name = x.WorldKey.GetName(),
                         },
                         comparison = x.Comparison,
-                        amount = x.Amount
-                    }).ToList()
+                        amount = x.Amount,
+                    }).ToList(),
                 });
             }
-            
+
             capabilityScriptable.actions.Clear();
             foreach (var actionConfig in this.config.Actions)
             {
@@ -137,11 +136,11 @@ namespace CrashKonijn.Goap.Editor
                 {
                     action = new ClassRef
                     {
-                        Name = this.GetName(actionConfig.ClassType)
+                        Name = this.GetName(actionConfig.ClassType),
                     },
                     target = new ClassRef
                     {
-                        Name = actionConfig.Target.Name
+                        Name = actionConfig.Target.GetName(),
                     },
                     baseCost = actionConfig.BaseCost,
                     stoppingDistance = actionConfig.StoppingDistance,
@@ -149,22 +148,22 @@ namespace CrashKonijn.Goap.Editor
                     {
                         worldKey = new ClassRef
                         {
-                            Name = x.WorldKey.Name
+                            Name = x.WorldKey.GetName(),
                         },
                         comparison = x.Comparison,
-                        amount = x.Amount
+                        amount = x.Amount,
                     }).ToList(),
                     effects = actionConfig.Effects.Select(x => new CapabilityEffect
                     {
                         worldKey = new ClassRef
                         {
-                            Name = x.WorldKey.Name
+                            Name = x.WorldKey.GetName(),
                         },
                         effect = x.Increase ? EffectType.Increase : EffectType.Decrease,
-                    }).ToList()
+                    }).ToList(),
                 });
             }
-            
+
             capabilityScriptable.worldSensors.Clear();
             foreach (var worldSensorConfig in this.config.WorldSensors)
             {
@@ -172,15 +171,15 @@ namespace CrashKonijn.Goap.Editor
                 {
                     sensor = new ClassRef
                     {
-                        Name = this.GetName(worldSensorConfig.ClassType)
+                        Name = this.GetName(worldSensorConfig.ClassType),
                     },
                     worldKey = new ClassRef
                     {
-                        Name = worldSensorConfig.Key.Name
-                    }
+                        Name = worldSensorConfig.Key.GetName(),
+                    },
                 });
             }
-            
+
             capabilityScriptable.targetSensors.Clear();
             foreach (var targetSensorConfig in this.config.TargetSensors)
             {
@@ -188,15 +187,15 @@ namespace CrashKonijn.Goap.Editor
                 {
                     sensor = new ClassRef
                     {
-                        Name = this.GetName(targetSensorConfig.ClassType)
+                        Name = this.GetName(targetSensorConfig.ClassType),
                     },
                     targetKey = new ClassRef
                     {
-                        Name = targetSensorConfig.Key.Name
-                    }
+                        Name = targetSensorConfig.Key.GetName(),
+                    },
                 });
             }
-            
+
             EditorUtility.SetDirty(capabilityScriptable);
             AssetDatabase.SaveAssetIfDirty(capabilityScriptable);
             // Set selected object to the new capability scriptable
@@ -206,7 +205,7 @@ namespace CrashKonijn.Goap.Editor
         private string GetName(string fullName)
         {
             var parts = fullName.Split(',').First();
-            
+
             return parts.Split('.').Last();
         }
 
@@ -230,7 +229,7 @@ namespace CrashKonijn.Goap.Editor
                 {
                     bind(element as Label, list[index]);
                 },
-                selectionType = SelectionType.None
+                selectionType = SelectionType.None,
             };
             listView.AddToClassList("card");
             foldout.Add(listView);

--- a/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/ITargetKey.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/ITargetKey.cs
@@ -1,6 +1,4 @@
 ﻿namespace CrashKonijn.Goap.Core
 {
-    public interface ITargetKey : IConfig
-    {
-    }
+    public interface ITargetKey { }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IWorldKey.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IWorldKey.cs
@@ -1,6 +1,4 @@
 ﻿namespace CrashKonijn.Goap.Core
 {
-    public interface IWorldKey : IConfig
-    {
-    }
+    public interface IWorldKey { }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/TargetKeyBase.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/TargetKeyBase.cs
@@ -2,8 +2,5 @@
 
 namespace CrashKonijn.Goap.Runtime
 {
-    public abstract class TargetKeyBase : ITargetKey
-    {
-        public string Name { get; set; }
-    }
+    public abstract class TargetKeyBase : ITargetKey { }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/WorldKeyBase.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/WorldKeyBase.cs
@@ -2,8 +2,5 @@
 
 namespace CrashKonijn.Goap.Runtime
 {
-    public abstract class WorldKeyBase : IWorldKey
-    {
-        public string Name { get; set; }
-    }
+    public abstract class WorldKeyBase : IWorldKey { }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/KeyBuilderBase.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/KeyBuilderBase.cs
@@ -10,8 +10,11 @@ namespace CrashKonijn.Goap.Runtime
         public TInterface GetKey<TKey>()
             where TKey : TInterface
         {
-            var type = typeof(TKey);
+            return this.GetKey(typeof(TKey));
+        }
 
+        public TInterface GetKey(Type type)
+        {
             if (this.keys.TryGetValue(type, out var key))
             {
                 return key;
@@ -19,12 +22,9 @@ namespace CrashKonijn.Goap.Runtime
 
             key = (TInterface) Activator.CreateInstance(type);
 
-            this.InjectData(key);
             this.keys.Add(type, key);
 
             return key;
         }
-
-        protected abstract void InjectData(TInterface key);
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/TargetKeyBuilder.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/TargetKeyBuilder.cs
@@ -1,14 +1,6 @@
-﻿using CrashKonijn.Agent.Runtime;
-using CrashKonijn.Goap.Core;
+﻿using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
 {
-    public class TargetKeyBuilder : KeyBuilderBase<ITargetKey>
-    {
-        protected override void InjectData(ITargetKey key)
-        {
-            if (key is TargetKeyBase targetKey)
-                targetKey.Name = key.GetType().GetGenericTypeName();
-        }
-    }
+    public class TargetKeyBuilder : KeyBuilderBase<ITargetKey> { }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/TargetSensorBuilder.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/TargetSensorBuilder.cs
@@ -6,7 +6,9 @@ namespace CrashKonijn.Goap.Runtime
     public class TargetSensorBuilder<T> : TargetSensorBuilder
         where T : ITargetSensor
     {
-        public TargetSensorBuilder(TargetKeyBuilder targetKeyBuilder) : base(typeof(T), targetKeyBuilder) { }
+        public TargetSensorBuilder(TargetKeyBuilder targetKeyBuilder) : base(typeof(T), targetKeyBuilder)
+        {
+        }
         
         public TargetSensorBuilder<T> SetTarget<TTarget>()
             where TTarget : ITargetKey
@@ -36,6 +38,9 @@ namespace CrashKonijn.Goap.Runtime
                 Name = type.Name,
                 ClassType = type.AssemblyQualifiedName,
             };
+            
+            if (typeof(ITargetKey).IsAssignableFrom(type))
+                this.config.Key = this.targetKeyBuilder.GetKey(type);
         }
 
         public ITargetSensorConfig Build()

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/WorldKeyBuilder.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/WorldKeyBuilder.cs
@@ -1,14 +1,6 @@
-﻿using CrashKonijn.Agent.Runtime;
-using CrashKonijn.Goap.Core;
+﻿using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
 {
-    public class WorldKeyBuilder : KeyBuilderBase<IWorldKey>
-    {
-        protected override void InjectData(IWorldKey key)
-        {
-            if (key is WorldKeyBase worldKey)
-                worldKey.Name = key.GetType().GetGenericTypeName();
-        }
-    }
+    public class WorldKeyBuilder : KeyBuilderBase<IWorldKey> { }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/WorldSensorBuilder.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/WorldSensorBuilder.cs
@@ -36,6 +36,9 @@ namespace CrashKonijn.Goap.Runtime
                 Name = type.Name,
                 ClassType = type.AssemblyQualifiedName,
             };
+            
+            if (typeof(IWorldKey).IsAssignableFrom(type))
+                this.config.Key = this.worldKeyBuilder.GetKey(type);
         }
 
         public IWorldSensorConfig Build()

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/DuplicateTargetSensorValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/DuplicateTargetSensorValidator.cs
@@ -25,7 +25,7 @@ namespace CrashKonijn.Goap.Runtime
         {
             return agentTypeConfig.TargetSensors
                 .Where(x => x.Key != null)
-                .Select(x => x.Key.Name)
+                .Select(x => x.Key.GetName())
                 .ToArray();
         }
 

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/DuplicateWorldSensorValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/DuplicateWorldSensorValidator.cs
@@ -25,7 +25,7 @@ namespace CrashKonijn.Goap.Runtime
         {
             return agentTypeConfig.WorldSensors
                 .Where(x => x.Key != null)
-                .Select(x => x.Key.Name)
+                .Select(x => x.Key.GetName())
                 .Distinct()
                 .ToArray();
         }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/TargetKeySensorsValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/TargetKeySensorsValidator.cs
@@ -8,7 +8,7 @@ namespace CrashKonijn.Goap.Runtime
     {
         public void Validate(IAgentTypeConfig agentTypeConfig, IValidationResults results)
         {
-            var required = agentTypeConfig.GetTargetKeys().Select(x => x.Name);
+            var required = agentTypeConfig.GetTargetKeys().Select(x => x.GetName());
             var provided = this.GetTargetSensorKeys(agentTypeConfig).Concat(this.GetMultiSensorKeys(agentTypeConfig));
 
             var missing = required.Except(provided).ToHashSet();
@@ -23,7 +23,7 @@ namespace CrashKonijn.Goap.Runtime
         {
             return agentTypeConfig.TargetSensors
                 .Where(x => x.Key != null)
-                .Select(x => x.Key.Name)
+                .Select(x => x.Key.GetName())
                 .Distinct()
                 .ToArray();
         }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/WorldKeySensorsValidator.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Validators/WorldKeySensorsValidator.cs
@@ -8,7 +8,7 @@ namespace CrashKonijn.Goap.Runtime
     {
         public void Validate(IAgentTypeConfig agentTypeConfig, IValidationResults results)
         {
-            var required = agentTypeConfig.GetWorldKeys().Select(x => x.Name).Distinct();
+            var required = agentTypeConfig.GetWorldKeys().Select(x => x.GetName()).Distinct();
             var provided = this.GetWorldSensorKeys(agentTypeConfig).Concat(this.GetMultiSensorKeys(agentTypeConfig));
 
             var missing = required.Except(provided).ToHashSet();
@@ -23,7 +23,7 @@ namespace CrashKonijn.Goap.Runtime
         {
             return agentTypeConfig.WorldSensors
                 .Where(x => x.Key != null)
-                .Select(x => x.Key.Name)
+                .Select(x => x.Key.GetName())
                 .Distinct()
                 .ToArray();
         }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Configs/TargetKey.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Configs/TargetKey.cs
@@ -1,7 +1,9 @@
-﻿using CrashKonijn.Goap.Core;
+﻿using System;
+using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
 {
+    [Obsolete("Use your own implementation of ITargetKey instead!")]
     public class TargetKey : ITargetKey
     {
         public TargetKey(string name)

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Configs/WorldKey.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Configs/WorldKey.cs
@@ -1,7 +1,9 @@
-﻿using CrashKonijn.Goap.Core;
+﻿using System;
+using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
 {
+    [Obsolete("Use your own implementation of IWorldKey instead!")]
     public class WorldKey : IWorldKey
     {
         public WorldKey(string name)

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Extensions.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Extensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using CrashKonijn.Agent.Core;
+using CrashKonijn.Agent.Runtime;
 using CrashKonijn.Goap.Core;
 using JetBrains.Annotations;
 using UnityEngine;
@@ -17,7 +17,7 @@ namespace CrashKonijn.Goap.Runtime
 
             return mono == null;
         }
-        
+
         public static string ToName(this Comparison comparison)
         {
             return comparison switch
@@ -102,16 +102,6 @@ namespace CrashKonijn.Goap.Runtime
 
             var instance = Activator.CreateInstance(script.Type);
 
-            if (instance is TargetKeyBase targetKey)
-            {
-                targetKey.Name = script.Type.Name;
-            }
-
-            if (instance is WorldKeyBase worldKey)
-            {
-                worldKey.Name = script.Type.Name;
-            }
-
             return instance as T;
         }
 
@@ -153,6 +143,22 @@ namespace CrashKonijn.Goap.Runtime
                 .Select(x => x.Target)
                 .Distinct()
                 .ToArray();
+        }
+
+        public static string GetName(this IWorldKey key)
+        {
+            if (key == null)
+                return "UNDEFINED";
+
+            return key.GetType().GetGenericTypeName();
+        }
+
+        public static string GetName(this ITargetKey key)
+        {
+            if (key == null)
+                return "UNDEFINED";
+
+            return key.GetType().GetGenericTypeName();
         }
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Resolvers/KeyResolver.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Resolvers/KeyResolver.cs
@@ -8,17 +8,17 @@ namespace CrashKonijn.Goap.Runtime
     {
         protected override string GetKey(IAction action, ICondition condition)
         {
-            return condition.WorldKey.Name + this.GetText(condition.Comparison);
+            return condition.WorldKey.GetName() + this.GetText(condition.Comparison);
         }
 
         protected override string GetKey(IAction action, IEffect effect)
         {
-            return effect.WorldKey.Name + this.GetText(effect.Increase);
+            return effect.WorldKey.GetName() + this.GetText(effect.Increase);
         }
 
         protected override string GetKey(IGoal action, ICondition condition)
         {
-            return condition.WorldKey.Name + this.GetText(condition.Comparison);
+            return condition.WorldKey.GetName() + this.GetText(condition.Comparison);
         }
 
         private string GetText(bool value)

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Scriptables/Legacy/TargetKeyScriptable.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Scriptables/Legacy/TargetKeyScriptable.cs
@@ -5,8 +5,5 @@ using UnityEngine;
 namespace CrashKonijn.Goap.Runtime
 {
     [Obsolete("Use CapabilityConfigs instead!")]
-    public class TargetKeyScriptable : ScriptableObject, ITargetKey
-    {
-        public string Name => this.name;
-    }
+    public class TargetKeyScriptable : ScriptableObject, ITargetKey { }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Scriptables/Legacy/WorldKeyScriptable.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Scriptables/Legacy/WorldKeyScriptable.cs
@@ -5,8 +5,5 @@ using UnityEngine;
 namespace CrashKonijn.Goap.Runtime
 {
     [Obsolete("Use CapabilityConfigs instead!")]
-    public class WorldKeyScriptable : ScriptableObject, IWorldKey
-    {
-        public string Name => this.name;
-    }
+    public class WorldKeyScriptable : ScriptableObject, IWorldKey { }
 }


### PR DESCRIPTION
- Removed unneeded Name property from `IWorldKey` and `ITargetKey`
- If a WorldSensor config is added using code and the sensor type also extends `IWorldKey`, the key is auto added.
- If a TargetSensor config is added using code and the sensor type also extends `ITargetKey`, the key is auto added.