### PR TITLE
Fix: Missing reference in tutorial

### DIFF
--- a/Package/Documentation/Introduction/Pears.md
+++ b/Package/Documentation/Introduction/Pears.md
@@ -225,6 +225,8 @@ namespace CrashKonijn.Docs.GettingStarted.Capabilities
                 .AddEffect<PearCount>(EffectType.Increase)
                 .SetTarget<ClosestPear>();
 
+            builder.AddMultiSensor<PearSensor>();
+
             return builder.Build();
         }
     }


### PR DESCRIPTION
This pull request includes an enhancement to the `Package/Documentation/Introduction/Pears.md` file. The most important change is the addition of a new sensor to the builder configuration.

Enhancement to documentation:

* [`Package/Documentation/Introduction/Pears.md`](diffhunk://#diff-4748690271c80e7082da127dad969b4db66646b5ad1468c41f1a096d98bd9ae5R228-R229): Added `PearSensor` to the builder with the `AddMultiSensor` method.