### PR TITLE
Corrects agent type string

### DIFF
--- a/Package/Documentation/Introduction/Setup.md
+++ b/Package/Documentation/Introduction/Setup.md
@@ -363,7 +363,7 @@ namespace CrashKonijn.Docs.GettingStarted.Behaviours
             
             // This only applies sto the code demo
             if (this.provider.AgentTypeBehaviour == null)
-                this.provider.AgentType = this.goap.GetAgentType("DemoAgent");
+                this.provider.AgentType = this.goap.GetAgentType("ScriptDemoAgent");
         }
 
         private void Start()


### PR DESCRIPTION
Following this guide using scripts method, the string used to for GetAgentType is incorrect and should be "ScriptDemoAgent"