### PR TITLE
Enhanced Goal Request Flexibility in GoapActionProvider

### DIFF
--- a/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IAgentType.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IAgentType.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace CrashKonijn.Goap.Core
 {
@@ -19,6 +20,7 @@ namespace CrashKonijn.Goap.Core
 
         TGoal ResolveGoal<TGoal>()
             where TGoal : IGoal;
+        IGoal ResolveGoal(Type goalType);
 
         bool AllConditionsMet(IGoapActionProvider actionProvider, IGoapAction action);
     }

--- a/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IGoapActionProvider.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Core/Interfaces/IGoapActionProvider.cs
@@ -22,33 +22,36 @@ namespace CrashKonijn.Goap.Core
         [Obsolete("Use RequestGoal instead.")]
         void SetGoal(IGoal goal, bool endAction);
 
-        void RequestGoal<TGoal>(bool endAction)
+        void RequestGoal(Type[] goalTypes, bool resolve = true);
+        void RequestGoal(Type goalType, bool resolve = true);
+
+        void RequestGoal<TGoal>(bool resolve = true)
             where TGoal : IGoal;
 
-        void RequestGoal<TGoal1, TGoal2>(bool endAction)
+        void RequestGoal<TGoal1, TGoal2>(bool resolve = true)
             where TGoal1 : IGoal
             where TGoal2 : IGoal;
 
-        void RequestGoal<TGoal1, TGoal2, TGoal3>(bool endAction)
+        void RequestGoal<TGoal1, TGoal2, TGoal3>(bool resolve = true)
             where TGoal1 : IGoal
             where TGoal2 : IGoal
             where TGoal3 : IGoal;
 
-        void RequestGoal<TGoal1, TGoal2, TGoal3, TGoal4>(bool endAction)
+        void RequestGoal<TGoal1, TGoal2, TGoal3, TGoal4>(bool resolve = true)
             where TGoal1 : IGoal
             where TGoal2 : IGoal
             where TGoal3 : IGoal
             where TGoal4 : IGoal;
 
-        public void RequestGoal<TGoal1, TGoal2, TGoal3, TGoal4, TGoal5>(bool endAction)
+        public void RequestGoal<TGoal1, TGoal2, TGoal3, TGoal4, TGoal5>(bool resolve = true)
             where TGoal1 : IGoal
             where TGoal2 : IGoal
             where TGoal3 : IGoal
             where TGoal4 : IGoal
             where TGoal5 : IGoal;
 
-        void RequestGoal(IGoal goal, bool endAction);
-        void RequestGoal(IGoalRequest request, bool endAction);
+        void RequestGoal(IGoal goal, bool resolve = true);
+        void RequestGoal(IGoalRequest request, bool resolve = true);
 
         void SetAction(IGoalResult result);
         void ClearGoal();

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/GoapActionProvider.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/GoapActionProvider.cs
@@ -120,6 +120,22 @@ namespace CrashKonijn.Goap.Runtime
         }
 
         /// <summary>
+        /// Request goals of the specified type.
+        /// </summary>
+        /// <param name="resolve"></param>
+        /// <param name="goalType"></param>
+        public void RequestGoal(Type goalType, bool resolve = true)
+        {
+            this.ValidateSetup();
+
+            var request = this.GetRequestCache();
+            request.Goals.Clear();
+            request.Goals.Add(this.AgentType.ResolveGoal(goalType));
+
+            this.RequestGoal(request, resolve);
+        }
+
+        /// <summary>
         ///     Requests a goal of type TGoal.
         /// </summary>
         /// <typeparam name="TGoal">The type of the goal.</typeparam>
@@ -127,13 +143,7 @@ namespace CrashKonijn.Goap.Runtime
         public void RequestGoal<TGoal>(bool resolve = true)
             where TGoal : IGoal
         {
-            this.ValidateSetup();
-
-            var request = this.GetRequestCache();
-            request.Goals.Clear();
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal>());
-
-            this.RequestGoal(request, resolve);
+            this.RequestGoal(typeof(TGoal), resolve);
         }
 
         /// <summary>
@@ -146,14 +156,11 @@ namespace CrashKonijn.Goap.Runtime
             where TGoal1 : IGoal
             where TGoal2 : IGoal
         {
-            this.ValidateSetup();
-
-            var request = this.GetRequestCache();
-            request.Goals.Clear();
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal1>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal2>());
-
-            this.RequestGoal(request, resolve);
+            this.RequestGoal(new []
+            {
+                typeof(TGoal1),
+                typeof(TGoal2)
+            }, resolve);
         }
 
         /// <summary>
@@ -168,15 +175,12 @@ namespace CrashKonijn.Goap.Runtime
             where TGoal2 : IGoal
             where TGoal3 : IGoal
         {
-            this.ValidateSetup();
-
-            var request = this.GetRequestCache();
-            request.Goals.Clear();
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal1>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal2>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal3>());
-
-            this.RequestGoal(request, resolve);
+            this.RequestGoal(new []
+            {
+                typeof(TGoal1),
+                typeof(TGoal2),
+                typeof(TGoal3)
+            }, resolve);
         }
 
         /// <summary>
@@ -193,16 +197,13 @@ namespace CrashKonijn.Goap.Runtime
             where TGoal3 : IGoal
             where TGoal4 : IGoal
         {
-            this.ValidateSetup();
-
-            var request = this.GetRequestCache();
-            request.Goals.Clear();
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal1>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal2>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal3>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal4>());
-
-            this.RequestGoal(request, resolve);
+            this.RequestGoal(new []
+            {
+                typeof(TGoal1),
+                typeof(TGoal2),
+                typeof(TGoal3),
+                typeof(TGoal4)
+            }, resolve);
         }
 
         /// <summary>
@@ -221,18 +222,14 @@ namespace CrashKonijn.Goap.Runtime
             where TGoal4 : IGoal
             where TGoal5 : IGoal
         {
-            this.ValidateSetup();
-
-            var request = this.GetRequestCache();
-
-            request.Goals.Clear();
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal1>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal2>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal3>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal4>());
-            request.Goals.Add(this.AgentType.ResolveGoal<TGoal5>());
-
-            this.RequestGoal(request, resolve);
+            this.RequestGoal(new []
+            {
+                typeof(TGoal1),
+                typeof(TGoal2),
+                typeof(TGoal3),
+                typeof(TGoal4),
+                typeof(TGoal5)
+            }, resolve);
         }
 
         /// <summary>

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/GoapActionProvider.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/GoapActionProvider.cs
@@ -101,6 +101,25 @@ namespace CrashKonijn.Goap.Runtime
         }
 
         /// <summary>
+        /// Request goals of the specified types.
+        /// </summary>
+        /// <param name="resolve"></param>
+        /// <param name="goalTypes"></param>
+        public void RequestGoal(Type[] goalTypes, bool resolve = true)
+        {
+            this.ValidateSetup();
+
+            var request = this.GetRequestCache();
+            request.Goals.Clear();
+            foreach (var goalType in goalTypes)
+            {
+                request.Goals.Add(this.AgentType.ResolveGoal(goalType));
+            }
+
+            this.RequestGoal(request, resolve);
+        }
+
+        /// <summary>
         ///     Requests a goal of type TGoal.
         /// </summary>
         /// <typeparam name="TGoal">The type of the goal.</typeparam>

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/AgentType.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/AgentType.cs
@@ -50,6 +50,14 @@ namespace CrashKonijn.Goap.Runtime
             throw new KeyNotFoundException($"No action found of type {typeof(TGoal)}");
         }
 
+        public IGoal ResolveGoal(Type goalType)
+        {
+            if (this.goalsLookup.TryGetValue(goalType, out var result))
+                return result;
+
+            throw new KeyNotFoundException($"No action found of type {goalType}");
+        }
+
         public bool AllConditionsMet(IGoapActionProvider actionProvider, IGoapAction action)
         {
             var conditionObserver = this.GoapConfig.ConditionObserver;

--- a/Package/Tests/CrashKonijn.Goap.Tests/UnitTests/AgentBehaviourTests.cs
+++ b/Package/Tests/CrashKonijn.Goap.Tests/UnitTests/AgentBehaviourTests.cs
@@ -111,7 +111,7 @@ namespace CrashKonijn.Goap.UnitTests
         public void RequestGoal_SetsGoalRequest()
         {
             // Arrange
-            this.agentType.ResolveGoal<TestGoal>().Returns(new TestGoal());
+            this.agentType.ResolveGoal(Arg.Any<Type>()).Returns(new TestGoal());
 
             this.provider.AgentType = this.agentType;
 


### PR DESCRIPTION
The current `GoapActionProvider` implementation has two limitations:
1. It only supports requesting goals via generic type parameters, which limits the number of goals that can be requested
2. It doesn't support dynamic goal requests from external configuration files (CSV/JSON/XML)

Added support for requesting goals by passing Type objects directly. This enables:
- Dynamic goal creation from configuration files
- No limit on the number of goals that can be requested simultaneously

```csharp
// Before - Limited to generic parameters
_provider.RequestGoal<IdleGoal>();

// After - Supports dynamic goal requests
RequestGoal("IdleGoal");

private void RequestGoal(params string[] goals)
{
    var assembly = Assembly.GetExecutingAssembly();
    var types = goals.Select(goal => assembly.GetType($"Sample.{goal}")).ToArray();
    _provider.RequestGoal(types);
}
```