### PR TITLE
Enhancement: Allow AgentTypeBehaviour to be more easily subclassed

### DIFF
--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/AgentTypeBehaviour.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/AgentTypeBehaviour.cs
@@ -7,15 +7,15 @@ namespace CrashKonijn.Goap.Runtime
     public class AgentTypeBehaviour : MonoBehaviour
     {
         [SerializeField]
-        private AgentTypeScriptable config;
+        protected AgentTypeScriptable config;
 
         [SerializeField]
-        private GoapBehaviour runner;
+        protected GoapBehaviour runner;
 
         public IAgentType AgentType { get; private set; }
         public AgentTypeScriptable Config => this.config;
 
-        private void Awake()
+        protected virtual void Awake()
         {
             var config = this.config.Create();
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
In order to inherit from AgentTypeBehaviour, I need to be able to set the `AgentTypeScriptable config` and `GoapBehaviour runner` and override the Awake logic if neccessary.
