### PR TITLE
Fixed missing distance multiplier field in GoapActionProviderEditor

### DIFF
--- a/Package/Editor/CrashKonijn.Goap.Editor/TypeDrawers/GoapActionProviderEditor.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/TypeDrawers/GoapActionProviderEditor.cs
@@ -19,6 +19,7 @@ namespace CrashKonijn.Goap.Editor
             root.styleSheets.Add(AssetDatabase.LoadAssetAtPath<StyleSheet>($"{GoapEditorSettings.BasePath}/Styles/Generic.uss"));
 
             root.Add(new PropertyField(this.serializedObject.FindProperty("<AgentTypeBehaviour>k__BackingField")));
+            root.Add(new PropertyField(this.serializedObject.FindProperty("<DistanceMultiplier>k__BackingField")));
             root.Add(new PropertyField(this.serializedObject.FindProperty("<LoggerConfig>k__BackingField")));
 
             if (!Application.isPlaying)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dd23f418-e433-4c2c-8956-a2f331b80529)
