### PR TITLE
Fix GoapActionBase subclasses not rendering ActionProperties in Capabilities

### DIFF
--- a/Package/Editor/CrashKonijn.Goap.Editor/Elements/ActionPropertiesElement.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/Elements/ActionPropertiesElement.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using CrashKonijn.Agent.Core;
-using CrashKonijn.Agent.Runtime;
 using CrashKonijn.Goap.Core;
 using CrashKonijn.Goap.Runtime;
 using UnityEditor;
@@ -23,22 +22,22 @@ namespace CrashKonijn.Goap.Editor
         public void Bind(SerializedProperty property, CapabilityAction action, Script[] actions)
         {
             this.validate(action, actions);
-                
+
             this.Render(action.properties, property.FindPropertyRelative("properties"));
         }
 
         private void Render(IActionProperties props, SerializedProperty property)
         {
             this.Clear();
-            
+
             if (props == null)
                 return;
-            
+
             var type = props.GetType();
 
             var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
             var fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
-            
+
             this.Add(new Label("Action props"));
             this.Add(new Card((card) =>
             {
@@ -47,12 +46,12 @@ namespace CrashKonijn.Goap.Editor
                     card.Add(new Label("No properties"));
                     return;
                 }
-                
+
                 foreach (var propertyInfo in properties)
                 {
                     this.AddProp(card, property.FindPropertyRelative(propertyInfo.Name));
                 }
-            
+
                 foreach (var propertyInfo in fields)
                 {
                     this.AddProp(card, property.FindPropertyRelative(propertyInfo.Name));
@@ -74,18 +73,18 @@ namespace CrashKonijn.Goap.Editor
 
             if (status != ClassRefStatus.Full)
                 return;
-            
+
             var type = this.GetPropertiesType(script);
-            
+
             if (type == null)
                 return;
-            
+
 
             if (action.properties?.GetType() == type)
             {
                 return;
             }
-            
+
             action.properties = (IActionProperties) Activator.CreateInstance(type);
         }
 
@@ -93,33 +92,11 @@ namespace CrashKonijn.Goap.Editor
         {
             if (script == null)
                 return null;
-            
-            var type = script.Type;
-            var baseType = type.BaseType;
-            
-            if (baseType == null)
+
+            if (script.Type == null)
                 return null;
-            
-            // recursively find the base type that is a GoapActionBase<,> or GoapActionBase<>
-            while (!IsGoapActionBase(baseType))
-            {
-                if (baseType.BaseType == null)
-                    return null;
-                baseType = baseType.BaseType;
-            }
 
-            if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<,>))
-                return baseType.GetGenericArguments()[1];
-            
-            if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<>)) 
-                return typeof(EmptyActionProperties);
-            
-            return null;
-        }
-
-        private bool IsGoapActionBase(Type type)
-        {
-            return type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(GoapActionBase<,>) || type.GetGenericTypeDefinition() == typeof(GoapActionBase<>));
+            return script.Type.GetPropertiesType();
         }
     }
 }

--- a/Package/Editor/CrashKonijn.Goap.Editor/Elements/ActionPropertiesElement.cs
+++ b/Package/Editor/CrashKonijn.Goap.Editor/Elements/ActionPropertiesElement.cs
@@ -100,13 +100,26 @@ namespace CrashKonijn.Goap.Editor
             if (baseType == null)
                 return null;
             
-            if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<,>)) 
+            // recursively find the base type that is a GoapActionBase<,> or GoapActionBase<>
+            while (!IsGoapActionBase(baseType))
+            {
+                if (baseType.BaseType == null)
+                    return null;
+                baseType = baseType.BaseType;
+            }
+
+            if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<,>))
                 return baseType.GetGenericArguments()[1];
             
             if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<>)) 
                 return typeof(EmptyActionProperties);
             
             return null;
+        }
+
+        private bool IsGoapActionBase(Type type)
+        {
+            return type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(GoapActionBase<,>) || type.GetGenericTypeDefinition() == typeof(GoapActionBase<>));
         }
     }
 }

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/ActionBuilder.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Classes/Builders/ActionBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using CrashKonijn.Agent.Core;
-using CrashKonijn.Agent.Runtime;
 using CrashKonijn.Goap.Core;
 
 namespace CrashKonijn.Goap.Runtime
@@ -188,7 +187,7 @@ namespace CrashKonijn.Goap.Runtime
             this.worldKeyBuilder = worldKeyBuilder;
             this.targetKeyBuilder = targetKeyBuilder;
 
-            var propType = this.GetPropertiesType();
+            var propType = this.actionType.GetPropertiesType();
 
             this.config = new ActionConfig
             {
@@ -205,30 +204,12 @@ namespace CrashKonijn.Goap.Runtime
 
         protected void ValidateProperties(IActionProperties properties)
         {
-            var actionPropsType = this.GetPropertiesType();
+            var actionPropsType = this.actionType.GetPropertiesType();
 
             if (actionPropsType == properties.GetType())
                 return;
 
             throw new ArgumentException($"The provided properties do not match the expected type '{actionPropsType.Name}'.", nameof(properties));
-        }
-
-        protected Type GetPropertiesType()
-        {
-            var baseType = this.actionType.BaseType;
-
-            while (baseType != null)
-            {
-                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<,>))
-                    return baseType.GetGenericArguments()[1];
-
-                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<>))
-                    return typeof(EmptyActionProperties);
-
-                baseType = baseType.BaseType;
-            }
-
-            return null;
         }
 
         public IActionConfig Build()

--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Extensions.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Extensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using CrashKonijn.Agent.Core;
+using CrashKonijn.Agent.Runtime;
 using CrashKonijn.Goap.Core;
 using JetBrains.Annotations;
 using UnityEngine;
@@ -17,7 +17,7 @@ namespace CrashKonijn.Goap.Runtime
 
             return mono == null;
         }
-        
+
         public static string ToName(this Comparison comparison)
         {
             return comparison switch
@@ -153,6 +153,24 @@ namespace CrashKonijn.Goap.Runtime
                 .Select(x => x.Target)
                 .Distinct()
                 .ToArray();
+        }
+
+        public static Type GetPropertiesType(this Type type)
+        {
+            var baseType = type;
+
+            while (baseType != null)
+            {
+                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<,>))
+                    return baseType.GetGenericArguments()[1];
+
+                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(GoapActionBase<>))
+                    return typeof(EmptyActionProperties);
+
+                baseType = baseType.BaseType;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION

 `ActionPropertiesElement` doesnt support displaying Action Properties if the Actions don't directly inherit from `GoapActionBase<,>` 
 
 In my usecase, I have a subclass of GoapActionBase to perform my own abstractions
 
 For example:
 ```cs
    public class MyAction : MyActionBase<MyAction.Data, MyAction.Props>
    {
        public override IActionRunState Perform(IMonoAgent agent, Data data, IActionContext context) => throw new System.NotImplementedException();

        public class Props : IActionProperties
        {
            public bool MyBool;
        }

        public class Data : SharedData
        {
            public int MyInt;
        }
    }

    public class SharedData : IActionData
    {
        public ITarget Target { get; set; }
        public string someSharedData;
    }

    public abstract class MyActionBase<TActionData> : MyActionBase<TActionData, EmptyActionProperties>
        where TActionData : SharedData, new()
    { }

    public abstract class MyActionBase<TActionData, TActionProperties> : GoapActionBase<TActionData, TActionProperties>
        where TActionData : SharedData, new()
        where TActionProperties : class, IActionProperties, new()
    {}
 ```

Without the fix, the Action props do not appear. With the fix they do as shown below.
![image](https://github.com/user-attachments/assets/624f1cee-74ed-4c95-8d6e-44ea95bf643d)
