### PR TITLE
Change Logger property to a settable property

### DIFF
--- a/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/GoapActionProvider.cs
+++ b/Package/Runtime/CrashKonijn.Goap.Runtime/Behaviours/GoapActionProvider.cs
@@ -45,7 +45,7 @@ namespace CrashKonijn.Goap.Runtime
 
         public ILocalWorldData WorldData { get; } = new LocalWorldData();
         public IGoapAgentEvents Events { get; } = new GoapAgentEvents();
-        public ILogger<IMonoGoapActionProvider> Logger { get; } = new GoapAgentLogger();
+        public ILogger<IMonoGoapActionProvider> Logger { get; set; } = new GoapAgentLogger();
 
         public Vector3 Position => this.transform.position;
 


### PR DESCRIPTION
This pull request makes a small change to the `GoapActionProvider` class, allowing the `Logger` property to be set externally rather than being read-only. This increases flexibility for dependency injection or runtime configuration.

* Changed `Logger` property from a read-only getter to a settable property in `GoapActionProvider`, enabling external assignment of the logger instance.